### PR TITLE
Fixed every MSVC warning

### DIFF
--- a/src/vmaware.hpp
+++ b/src/vmaware.hpp
@@ -9,7 +9,7 @@
  *  A C++ VM detection library
  * 
  *  - Made by: @kernelwernel (https://github.com/kernelwernel)
- *  - Contributed by @Requirem (https://github.com/NotRequiem)
+ *  - Contributed by @Requiem (https://github.com/NotRequiem)
  *  - Repository: https://github.com/kernelwernel/VMAware
  *  - Docs: https://github.com/kernelwernel/VMAware/docs/documentation.md
  *  - Full credits: https://github.com/kernelwernel/VMAware#credits
@@ -2984,22 +2984,34 @@ private:
                 iBuffSize = sizeof(szBuff);
                 nRes = RegQueryValueEx(hOpen, "ProductId", NULL, NULL, (unsigned char*)szBuff, reinterpret_cast<LPDWORD>(&iBuffSize));
                 if (nRes == ERROR_SUCCESS) {
-                    if (strcmp(szBuff, "55274-640-2673064-23950") == 0) { // joebox
-                        free(szBuff);
-                        return add(JOEBOX);
-                    } else if (strcmp(szBuff, "76487-644-3177037-23510") == 0) {
-                        free(szBuff);
-                        return add(CWSANDBOX); // CW Sandbox
-                    } else if (strcmp(szBuff, "76487-337-8429955-22614") == 0) { // anubis
-                        free(szBuff);
-                        return add(ANUBIS);
-                    } else {
-                        free(szBuff);
+                    // Check if szBuff is not NULL before using strcmp
+                    if (szBuff != NULL) {
+                        if (strcmp(szBuff, "55274-640-2673064-23950") == 0) { // joebox
+                            free(szBuff);
+                            return add(JOEBOX);
+                        }
+                        else if (strcmp(szBuff, "76487-644-3177037-23510") == 0) {
+                            free(szBuff);
+                            return add(CWSANDBOX); // CW Sandbox
+                        }
+                        else if (strcmp(szBuff, "76487-337-8429955-22614") == 0) { // anubis
+                            free(szBuff);
+                            return add(ANUBIS);
+                        }
+                        else {
+                            free(szBuff);
+                            return false;
+                        }
+                    }
+                    else {
+                        // Handle the case when szBuff is NULL
+                        RegCloseKey(hOpen);
                         return false;
                     }
                 }
                 RegCloseKey(hOpen);
             }
+            // Set szBuff to NULL after freeing to avoid double free issues
             free(szBuff);
             return false;
         #endif
@@ -3340,13 +3352,13 @@ private:
 
                 hDll = GetModuleHandle(dll);
 
-                if (hDll != NULL) {
-                    if (strcmp(dll, "sbiedll.dll") == 0) { return add(SANDBOXIE); }
-                    if (strcmp(dll, "pstorec.dll") == 0) { return add(SUNBELT); }
-                    if (strcmp(dll, "vmcheck.dll") == 0) { return add(VPC); }
-                    if (strcmp(dll, "cmdvrt64.dll") == 0) { return add(COMODO); }
-                    if (strcmp(dll, "cmdvrt32.dll") == 0) { return add(COMODO); }
-                    return true;
+                if (hDll != NULL && dll != NULL) {
+                if (strcmp(dll, "sbiedll.dll") == 0) { return add(SANDBOXIE); }
+                if (strcmp(dll, "pstorec.dll") == 0) { return add(SUNBELT); }
+                if (strcmp(dll, "vmcheck.dll") == 0) { return add(VPC); }
+                if (strcmp(dll, "cmdvrt64.dll") == 0) { return add(COMODO); }
+                if (strcmp(dll, "cmdvrt32.dll") == 0) { return add(COMODO); }
+                return true;
                 }
             }
 
@@ -3554,6 +3566,7 @@ private:
                 }
 
                 VARIANT vtProp;
+                VariantInit(&vtProp);
                 hr = pclsObj->Get(L"Manufacturer", 0, &vtProp, 0, 0);
 
                 if (SUCCEEDED(hr)) {


### PR DESCRIPTION
Fixed every compiler warning for all c++ versions on windows systems (not really necessary tho, the library is quite well-made)

'dll' could be '0':  this does not adhere to the specification for the function 'strcmp'. vmaware.hpp - 3410
		
'szBuff' could be '0':  this does not adhere to the specification for the function 'strcmp'. vmaware.hpp - 3045
		
VARIANT '&vtProp' was provided as an _In_ or _InOut_ parameter but was not initialized (expression 'vtProp').	vmaware.hpp - 3626		
