### PR TITLE
fix constant value error for vm_files_extra

### DIFF
--- a/src/vmaware.hpp
+++ b/src/vmaware.hpp
@@ -5207,15 +5207,15 @@ private: // START OF PRIVATE VM DETECTION TECHNIQUE DEFINITIONS
         return false;
 #else
         constexpr std::array<std::pair<const char*, const TCHAR*>, 9> files = { {
-            { VPC, "c:\\windows\\system32\\drivers\\vmsrvc.sys" },
-            { VPC, "c:\\windows\\system32\\drivers\\vpc-s3.sys" },
-            { PARALLELS, "c:\\windows\\system32\\drivers\\prleth.sys" },
-            { PARALLELS, "c:\\windows\\system32\\drivers\\prlfs.sys" },
-            { PARALLELS, "c:\\windows\\system32\\drivers\\prlmouse.sys" },
-            { PARALLELS, "c:\\windows\\system32\\drivers\\prlvideo.sys" },
-            { PARALLELS, "c:\\windows\\system32\\drivers\\prltime.sys" },
-            { PARALLELS, "c:\\windows\\system32\\drivers\\prl_pv32.sys" },
-            { PARALLELS, "c:\\windows\\system32\\drivers\\prl_paravirt_32.sys" }
+            { VPC, L"c:\\windows\\system32\\drivers\\vmsrvc.sys" },
+            { VPC, L"c:\\windows\\system32\\drivers\\vpc-s3.sys" },
+            { PARALLELS, L"c:\\windows\\system32\\drivers\\prleth.sys" },
+            { PARALLELS, L"c:\\windows\\system32\\drivers\\prlfs.sys" },
+            { PARALLELS, L"c:\\windows\\system32\\drivers\\prlmouse.sys" },
+            { PARALLELS, L"c:\\windows\\system32\\drivers\\prlvideo.sys" },
+            { PARALLELS, L"c:\\windows\\system32\\drivers\\prltime.sys" },
+            { PARALLELS, L"c:\\windows\\system32\\drivers\\prl_pv32.sys" },
+            { PARALLELS, L"c:\\windows\\system32\\drivers\\prl_paravirt_32.sys" }
         } };
 
         for (const auto &file_pair : files) {

--- a/src/vmaware.hpp
+++ b/src/vmaware.hpp
@@ -5206,16 +5206,16 @@ private: // START OF PRIVATE VM DETECTION TECHNIQUE DEFINITIONS
 #if (!MSVC)
         return false;
 #else
-        constexpr std::array<std::pair<const char*, const TCHAR*>, 9> files = { {
-            { VPC, L"c:\\windows\\system32\\drivers\\vmsrvc.sys" },
-            { VPC, L"c:\\windows\\system32\\drivers\\vpc-s3.sys" },
-            { PARALLELS, L"c:\\windows\\system32\\drivers\\prleth.sys" },
-            { PARALLELS, L"c:\\windows\\system32\\drivers\\prlfs.sys" },
-            { PARALLELS, L"c:\\windows\\system32\\drivers\\prlmouse.sys" },
-            { PARALLELS, L"c:\\windows\\system32\\drivers\\prlvideo.sys" },
-            { PARALLELS, L"c:\\windows\\system32\\drivers\\prltime.sys" },
-            { PARALLELS, L"c:\\windows\\system32\\drivers\\prl_pv32.sys" },
-            { PARALLELS, L"c:\\windows\\system32\\drivers\\prl_paravirt_32.sys" }
+        constexpr std::array<std::pair<const char*, const char*>, 9> files = { {
+            { VPC, "c:\\windows\\system32\\drivers\\vmsrvc.sys" },
+            { VPC, "c:\\windows\\system32\\drivers\\vpc-s3.sys" },
+            { PARALLELS, "c:\\windows\\system32\\drivers\\prleth.sys" },
+            { PARALLELS, "c:\\windows\\system32\\drivers\\prlfs.sys" },
+            { PARALLELS, "c:\\windows\\system32\\drivers\\prlmouse.sys" },
+            { PARALLELS, "c:\\windows\\system32\\drivers\\prlvideo.sys" },
+            { PARALLELS, "c:\\windows\\system32\\drivers\\prltime.sys" },
+            { PARALLELS, "c:\\windows\\system32\\drivers\\prl_pv32.sys" },
+            { PARALLELS, "c:\\windows\\system32\\drivers\\prl_paravirt_32.sys" }
         } };
 
         for (const auto &file_pair : files) {


### PR DESCRIPTION
This fixes the following warnings and compiler errors in VS2022 and VSCode.

`error C2131: expression did not evaluate to a constant` `expression must have a constant value C/C++(28)`