### PR TITLE
stupid change to avoid compiler warning

### DIFF
--- a/src/vmaware.hpp
+++ b/src/vmaware.hpp
@@ -1982,27 +1982,27 @@ private:
             typedef NTSTATUS(WINAPI* RtlGetVersionFunc)(PRTL_OSVERSIONINFOW);
 
             const std::map<DWORD, u8> windowsVersions = {
-                { 6002, 6 }, // windows vista, technically no number but this function is just for great than operations anyway so it doesn't matter
-                { 7601, 7 },
-                { 9200, 8 },
-                { 9600, 8 },
-                { 10240, 10 },
-                { 10586, 10 },
-                { 14393, 10 },
-                { 15063, 10 },
-                { 16299, 10 },
-                { 17134, 10 },
-                { 17763, 10 },
-                { 18362, 10 },
-                { 18363, 10 },
-                { 19041, 10 },
-                { 19042, 10 },
-                { 19043, 10 },
-                { 19044, 10 },
-                { 19045, 10 },
-                { 22000, 11 },
-                { 22621, 11 },
-                { 22631, 11 }
+                { 6002, static_cast<u8>(6) }, // windows vista, technically no number but this function is just for great than operations anyway so it doesn't matter
+                { 7601, static_cast<u8>(7) },
+                { 9200, static_cast<u8>(8) },
+                { 9600, static_cast<u8>(8) },
+                { 10240, static_cast<u8>(10) },
+                { 10586, static_cast<u8>(10) },
+                { 14393, static_cast<u8>(10) },
+                { 15063, static_cast<u8>(10) },
+                { 16299, static_cast<u8>(10) },
+                { 17134, static_cast<u8>(10) },
+                { 17763, static_cast<u8>(10) },
+                { 18362, static_cast<u8>(10) },
+                { 18363, static_cast<u8>(10) },
+                { 19041, static_cast<u8>(10) },
+                { 19042, static_cast<u8>(10) },
+                { 19043, static_cast<u8>(10) },
+                { 19044, static_cast<u8>(10) },
+                { 19045, static_cast<u8>(10) },
+                { 22000, static_cast<u8>(11) },
+                { 22621, static_cast<u8>(11) },
+                { 22631, static_cast<u8>(11) }
             };
 
             HMODULE ntdll = LoadLibraryW(L"ntdll.dll");


### PR DESCRIPTION
**Warning**
```
Warning	C4244	'initializing': conversion from '_Ty' to '_Ty2', possible loss of data
        with
        [
            _Ty=int
        ]
        and
        [
            _Ty2=VM::u8
        ]	C:\Program Files\Microsoft Visual Studio\2022\Community\VC\Tools\MSVC\14.41.34120\include\utility	247
```

**Explanation**
The warning suggests that converting between these types (i.e., from DWORD to u8) may cause data loss since DWORD is 32-bit and u8 is only 8-bit. 

**Solution**
All the values you're assigning to the u8 type are valid and will fit within uint8_t. Therefore, casting them as static_cast<u8> will work fine to supress the MSVC compiler warning without any data loss:

- The first value, 6, is well within the range of uint8_t (0-255).
- The rest of the values (7, 8, 10, 11) also fit within the valid range of uint8_t.

By explictly casting the values to "u8" (which is an alias for uint8_t) during initialization, we make it clear that we're aware of the conversion to the compiler.