### PR TITLE
Added new techniques

### DIFF
--- a/docs/documentation.md
+++ b/docs/documentation.md
@@ -469,6 +469,9 @@ VMAware provides a convenient way to not only check for VMs, but also have the f
 | `VM::CPU_FANS` | Check for CPU Fans | Windows | 35% |  |  |  |  |
 | `VM::POWER_CAPABILITIES` | Check what power states are enabled | Windows | 25% |  | GPL |  |  |
 | `VM::SETUPAPI_DISK` | Checks for virtual machine signatures in disk drive device identifiers | Windows | 20% |  | GPL |  |  |
+| `VM::HARDENER_LOADER` | Checks for VMwareHardenerLoader's method of patching firmware detection by setting its signatures with "7" | Windows | 50% |  |  |  |  |
+| `VM::WMI_QUERIES` | Executes generic WMI queries that always return more than 0 entries in physical machines and checks if any query returns zero entries | Windows | 50% |  | GPL |  |  |
+
 <!-- ADD DETAILS HERE -->
 
 <br>

--- a/src/cli.cpp
+++ b/src/cli.cpp
@@ -907,6 +907,8 @@ void general() {
     checker(VM::CPU_FANS, "CPU fans");
     checker(VM::POWER_CAPABILITIES, "Power capabilities");
     checker(VM::SETUPAPI_DISK, "SETUPDI diskdrive");
+    checker(VM::VMWARE_HARDENER, "VMWARE HARDENER");
+    checker(VM::WMI_QUERIES, "WMI QUERIES");
     // ADD NEW TECHNIQUE CHECKER HERE
 
     std::printf("\n");

--- a/src/vmaware.hpp
+++ b/src/vmaware.hpp
@@ -454,6 +454,8 @@ public:
         WMI_TEMPERATURE,
         PROCESSOR_ID,
         CPU_FANS,
+        VMWARE_HARDENER,
+        WMI_QUERIES,
         // ADD NEW TECHNIQUE ENUM NAME HERE
 
         // start of settings technique flags (THE ORDERING IS VERY SPECIFIC HERE AND MIGHT BREAK SOMETHING IF RE-ORDERED)
@@ -1429,8 +1431,6 @@ public:
             }
 
             CoUninitialize();
-
-            core_debug("WMI has been cleaned");
         }
     };
 
@@ -1853,7 +1853,7 @@ public:
             DWORD numProcesses = bytesReturned / sizeof(DWORD);
 
             for (DWORD i = 0; i < numProcesses; ++i) {
-                const HANDLE process = OpenProcess(PROCESS_QUERY_INFORMATION, FALSE, processes[i]);
+                const HANDLE process = OpenProcess(PROCESS_QUERY_LIMITED_INFORMATION, FALSE, processes[i]);
                 if (process != nullptr) {
                     TCHAR processName[MAX_PATH];
                     if (GetModuleBaseName(process, nullptr, processName, sizeof(processName) / sizeof(TCHAR))) {
@@ -2615,7 +2615,7 @@ public:
 
         [[nodiscard]] static bool motherboard_string(const char* vm_string) {
             if (!wmi::initialize()) {
-                core_debug("Failed to initialize WMI");
+                core_debug("Failed to initialize WMI in motherboard_string");
                 return false;
             }
 
@@ -2877,7 +2877,7 @@ public:
 
             auto GetThreadsUsingWMI = []() -> int {
                 if (!wmi::initialize()) {
-                    std::cerr << "Failed to initialize WMI.\n";
+                    std::cerr << "Failed to initialize WMI in GetThreadsUsingWMI.\n";
                     return -1;
                 }
 
@@ -2903,10 +2903,6 @@ public:
             int cpuidThreads = GetThreadsUsingCPUID();
             int wmiThreads = GetThreadsUsingWMI();
             int osThreads = GetThreadsUsingOSAPI();
-
-            std::cout << "CPUID Threads: " << cpuidThreads << "\n";
-            std::cout << "WMI Threads: " << wmiThreads << "\n";
-            std::cout << "OS Threads: " << osThreads << "\n";
 
             return !(cpuidThreads == wmiThreads && wmiThreads == osThreads);
         }
@@ -4362,6 +4358,40 @@ private: // START OF PRIVATE VM DETECTION TECHNIQUE DEFINITIONS
 /* GPL */         return false;
 /* GPL */ #endif
 /* GPL */     }
+/* GPL */     // @brief Executes generic WMI queries that always return more than 0 entries in physical machines and checks if any query returns zero entries 
+/* GPL */     // @category Windows
+/* GPL */     // @author idea from Al-Khaser project
+/* GPL */     // @return True if all queries return non - zero results; false otherwise
+/* GPL */     [[nodiscard]] static bool wmi_queries() {
+/* GPL */ #if (!WINDOWS)
+/* GPL */         return false;
+/* GPL */ #else
+/* GPL */         if (!wmi::initialize()) {
+/* GPL */             core_debug("Failed to initialize WMI in wmi_queries.");
+/* GPL */             return false;
+/* GPL */         }
+/* GPL */
+/* GPL */        std::vector<std::wstring> queries = {
+/* GPL */           L"SELECT * FROM Win32_VoltageProbe",
+/* GPL */           L"SELECT * FROM Win32_PerfFormattedData_Counters_ThermalZoneInformation",
+/* GPL */           L"SELECT * FROM CIM_Sensor",
+/* GPL */           L"SELECT * FROM CIM_NumericSensor",
+/* GPL */           L"SELECT * FROM CIM_TemperatureSensor",
+/* GPL */           L"SELECT * FROM CIM_VoltageSensor"
+/* GPL */        };
+/* GPL */
+/* GPL */        for (const auto& query : queries) {
+/* GPL */           auto results = wmi::execute(query, {});
+/* GPL */           int count = results.size();
+/* GPL */
+/* GPL */           if (count > 0) {
+/* GPL */               return true;
+/* GPL */           }
+/* GPL */         }
+/* GPL */         return false;
+/* GPL */ #endif
+/* GPL */     }
+
 
 
     /**
@@ -5505,7 +5535,7 @@ private: // START OF PRIVATE VM DETECTION TECHNIQUE DEFINITIONS
         return false;
 #else
         if (!wmi::initialize()) {
-            core_debug("Failed to initialize WMI");
+            core_debug("Failed to initialize WMI in hyperv_board");
             return false;
         }
 
@@ -6060,7 +6090,7 @@ private: // START OF PRIVATE VM DETECTION TECHNIQUE DEFINITIONS
 #if (WINDOWS)
         if (util::does_threadcount_mismatch()) {
             debug("INTEL_THREAD_MISMATCH: Thread tampering detected");
-            return false;
+            return true;
         }
 #endif
 
@@ -8797,7 +8827,7 @@ private: // START OF PRIVATE VM DETECTION TECHNIQUE DEFINITIONS
         return false;
 #else
         if (!wmi::initialize()) {
-            core_debug("Failed to initialize WMI");
+            core_debug("Failed to initialize WMI in gpu_chiptype");
             return false;
         }
 
@@ -8919,7 +8949,7 @@ private: // START OF PRIVATE VM DETECTION TECHNIQUE DEFINITIONS
         return false;
 #else
         if (!wmi::initialize()) {
-            core_debug("HDD serial number: Failed to initialize WMI");
+            core_debug("Failed to initialize WMI in hdd_serial_number");
             return false;
         }
 
@@ -8950,6 +8980,7 @@ private: // START OF PRIVATE VM DETECTION TECHNIQUE DEFINITIONS
         return false;
 #else
         if (!wmi::initialize()) {
+            core_debug("Failed to initialize WMI in port_connectors");
             return false;
         }
 
@@ -8969,6 +9000,7 @@ private: // START OF PRIVATE VM DETECTION TECHNIQUE DEFINITIONS
         return false;
 #else
         if (!wmi::initialize()) {
+            core_debug("Failed to initialize WMI in vm_hdd");
             return false;
         }
 
@@ -9245,6 +9277,7 @@ private: // START OF PRIVATE VM DETECTION TECHNIQUE DEFINITIONS
         return false;
 #else
         if (!wmi::initialize()) {
+            core_debug("Failed to initialize WMI in number_of_cores");
             return false;
         }
 
@@ -9276,6 +9309,7 @@ private: // START OF PRIVATE VM DETECTION TECHNIQUE DEFINITIONS
         return false;
 #else
         if (!wmi::initialize()) {
+            core_debug("Failed to initialize WMI in number_of_cores");
             return false;
         }
 
@@ -9305,6 +9339,7 @@ private: // START OF PRIVATE VM DETECTION TECHNIQUE DEFINITIONS
         return false;
 #else
         if (!wmi::initialize()) {
+            core_debug("Failed to initialize WMI in wmi_manufacturer");
             return false;
         }
 
@@ -9334,6 +9369,7 @@ private: // START OF PRIVATE VM DETECTION TECHNIQUE DEFINITIONS
         return false;
 #else
         if (!wmi::initialize()) {
+            core_debug("Failed to initialize WMI in wmi_temperature");
             return false;
         }
 
@@ -9363,6 +9399,7 @@ private: // START OF PRIVATE VM DETECTION TECHNIQUE DEFINITIONS
         return false;
 #else
         if (!wmi::initialize()) {
+            core_debug("Failed to initialize WMI in processor_id");
             return false;
         }
 
@@ -9392,6 +9429,7 @@ private: // START OF PRIVATE VM DETECTION TECHNIQUE DEFINITIONS
         return false;
 #else
         if (!wmi::initialize()) {
+            core_debug("Failed to initialize WMI in cpu_fans");
             return false;
         }
 
@@ -9421,7 +9459,7 @@ static bool rdtsc() {
 #else
 
         u64 start, end, total_cycles = 0;
-        u32 eax, ebx, ecx, edx;
+        u32 eax = 0, ebx = 0, ecx = 0, edx = 0;
         i32 cpu_info[4];
 
         constexpr i32 iterations = 10000;
@@ -9452,6 +9490,69 @@ static bool rdtsc() {
     }
 
 
+    /*
+     * @brief Detects VMwareHardenerLoader's technique to remove firmware signatures
+     * @category Windows
+     * @author MegaMax
+     */
+    [[nodiscard]] static bool vmware_hardener()
+    {
+#if (!WINDOWS)
+        return false;
+#else
+        static const DWORD kProviders[] = { 'ACPI', 'RSMB', 'FIRM' };
+        static const char* kPatchedStrings[] = { "VMware", "VMWARE", "Virtual" };
+
+        for (DWORD provider : kProviders)
+        {
+            DWORD bufferSize = EnumSystemFirmwareTables(provider, NULL, 0);
+            if (bufferSize == 0)
+            {
+                return false;
+            }
+
+            std::vector<char> tableNames(bufferSize);
+            if (EnumSystemFirmwareTables(provider, tableNames.data(), (DWORD)tableNames.size()) == 0)
+            {
+                return false;
+            }
+
+            for (size_t i = 0; i < tableNames.size(); i += 4)
+            {
+                DWORD signature = *(DWORD*)&tableNames[i];
+
+                DWORD requiredSize = GetSystemFirmwareTable(provider, signature, NULL, 0);
+                if (requiredSize == 0)
+                {
+                    continue;
+                }
+
+                std::vector<BYTE> tableBuffer(requiredSize);
+                if (GetSystemFirmwareTable(provider, signature, tableBuffer.data(), requiredSize) == 0)
+                {
+                    continue;
+                }
+
+                std::string tableData((char*)tableBuffer.data(), tableBuffer.size());
+                for (const char* original : kPatchedStrings)
+                {
+                    size_t orig_len = strlen(original);
+                    if (tableData.find(original) == std::string::npos)
+                    {
+                        std::string replaced(orig_len, '7');
+                        if (tableData.find(replaced) != std::string::npos)
+                        {
+                            return core::add(brands::VMWARE);
+                        }
+                    }
+                }
+            }
+        }
+
+        return false;
+#endif
+    }
+ 
     // ADD NEW TECHNIQUE FUNCTION HERE
 
 
@@ -10490,6 +10591,8 @@ public: // START OF PUBLIC FUNCTIONS
             case CPU_FANS: return "CPU_FANS";
             case POWER_CAPABILITIES: return "POWER_CAPABILITIES";
             case SETUPAPI_DISK: return "SETUPAPI_DISK";
+            case VMWARE_HARDENER: return "VMWARE_HARDENER_LOADER";
+            case WMI_QUERIES: return "WMI_QUERIES";
             // ADD NEW CASE HERE FOR NEW TECHNIQUE
             default: return "Unknown flag";
         }
@@ -10953,6 +11056,7 @@ std::pair<VM::enum_flags, VM::core::technique> VM::core::technique_list[] = {
 /* GPL */ { VM::QEMU_DIR, { 30, VM::qemu_dir, true } },
 /* GPL */ { VM::POWER_CAPABILITIES, { 25, VM::power_capabilities, false } },
 /* GPL */ { VM::SETUPAPI_DISK, { 20, VM::setupapi_disk, false } },
+/* GPL */ { VM::WMI_QUERIES, { 50, VM::wmi_queries, false } },
     { VM::VM_PROCESSES, { 15, VM::vm_processes, true } }, 
     { VM::LINUX_USER_HOST, { 10, VM::linux_user_host, true } }, // TODO: update score
     { VM::GAMARUE, { 10, VM::gamarue, true } },
@@ -11042,6 +11146,7 @@ std::pair<VM::enum_flags, VM::core::technique> VM::core::technique_list[] = {
     { VM::WMI_TEMPERATURE, { 25, VM::wmi_temperature, false } },
     { VM::PROCESSOR_ID, { 25, VM::processor_id, false } },
     { VM::CPU_FANS, { 35, VM::cpu_fans, false } },
+    { VM::VMWARE_HARDENER, { 50, VM::vmware_hardener, false } },
     // ADD NEW TECHNIQUE STRUCTURE HERE
 };
 


### PR DESCRIPTION
# New features
- [X] Added WMI_QUERIES technique (GPL)
- [X] Added VMWARE_HARDENER_LOADER technique (MIT)
- [X] Updated documentation and CLI
- [X] Now the library will show the function that failed to initialize in case of a WMI error

# Fixes
- Returns true if a tamper attempt in the number of threads present in the system is detected
- Modified request access needed to detect if a process is running to PROCESS_QUERY_LIMITED_INFORMATION instead of PROCESS_QUERY_INFORMATION
- Removed debug output in GetThreadsUsingWMI for production builds