### PR TITLE
Hyper-X fix

### DIFF
--- a/docs/documentation.md
+++ b/docs/documentation.md
@@ -370,7 +370,6 @@ VMAware provides a convenient way to not only check for VMs, but also have the f
 | `VM::RDTSC_VMEXIT` | check through alternative RDTSC technique with VMEXIT |  | 25% |  |  |  | Disabled by default |
 | `VM::QEMU_BRAND` | Match for QEMU CPU brands with "QEMU Virtual CPU" string |  | 100% |  |  |  |  |
 | `VM::BOCHS_CPU` | Check for various Bochs-related emulation oversights through CPU checks |  | 95% |  |  |  |  |
-| `VM::VPC_BOARD` | Check through the motherboard and match for VirtualPC-specific string | Windows | 20% |  |  |  |  |
 | `VM::HYPERV_WMI` | Check WMI query for "Hyper-V RAW" string | Windows | 80% |  |  |  |  |
 | `VM::HYPERV_REG` | Check presence for Hyper-V specific string in registry | Windows | 80% |  |  |  |  |
 | `VM::BIOS_SERIAL` | Check if the BIOS serial is valid (null = VM) | Windows | 60% |  |  |  |  |
@@ -388,7 +387,6 @@ VMAware provides a convenient way to not only check for VMs, but also have the f
 | `VM::OFFSEC_SIDT` | Check for Offensive Security SIDT method | Windows | 60% |  |  | 32-bit |  |
 | `VM::OFFSEC_SGDT` | Check for Offensive Security SGDT method | Windows | 60% |  |  | 32-bit |  |
 | `VM::OFFSEC_SLDT` | Check for Offensive Security SLDT method | Windows | 20% |  |  | 32-bit |  |
-| `VM::HYPERV_BOARD` | Check for Hyper-V specific string in motherboard | Windows | 45% |  |  |  |  |
 | `VM::VPC_SIDT` | Check for sidt method with VPC's 0xE8XXXXXX range | Windows | 15% |  |  | 32-bit |  |
 | `VM::VMWARE_IOMEM` | Check for VMware string in /proc/iomem | Linux | 65% |  |  |  |  |
 | `VM::VMWARE_IOPORTS` | Check for VMware string in /proc/ioports | Linux | 70% |  |  |  |  |
@@ -457,6 +455,8 @@ VMAware provides a convenient way to not only check for VMs, but also have the f
 | `VM::SYS_QEMU` | Check for existence of "qemu_fw_cfg" directories within /sys/module and /sys/firmware | Linux | 70% |  |  |  |  |
 | `VM::LSHW_QEMU` | Check for QEMU string instances with lshw command | Linux | 80% |  |  |  |  |
 | `VM::VIRTUAL_PROCESSORS` | Checks if the number of maximum virtual processors matches the maximum number of logical processors | Windows | 35% |  |  |  |  |
+| `VM::MOTHERBOARD_PRODUCT` | Check if the motherboard product string matches "Virtual Machine" | Windows | 25% |  |  |  |  |
+
 <!-- ADD DETAILS HERE -->
 
 <br>

--- a/src/cli.cpp
+++ b/src/cli.cpp
@@ -409,7 +409,6 @@ bool is_unsupported(VM::enum_flags flag) {
             case VM::PARALLELS_VM:
             case VM::QEMU_BRAND:
             case VM::BOCHS_CPU:
-            case VM::VPC_BOARD:
             case VM::HYPERV_WMI:
             case VM::HYPERV_REG:
             case VM::BIOS_SERIAL:
@@ -422,7 +421,6 @@ bool is_unsupported(VM::enum_flags flag) {
             case VM::OFFSEC_SIDT:
             case VM::OFFSEC_SGDT:
             case VM::OFFSEC_SLDT:
-            case VM::HYPERV_BOARD:
             case VM::VPC_SIDT:
             case VM::VMWARE_STR:
             case VM::VMWARE_BACKDOOR:
@@ -466,6 +464,8 @@ bool is_unsupported(VM::enum_flags flag) {
             case VM::POWER_CAPABILITIES:
             case VM::SETUPAPI_DISK: 
             case VM::VMWARE_HARDENER:
+            case VM::VIRTUAL_PROCESSORS:
+            case VM::MOTHERBOARD_PRODUCT:
             // ADD WINDOWS FLAG
             return false;
             default: return true;
@@ -484,7 +484,6 @@ bool is_unsupported(VM::enum_flags flag) {
             case VM::VMID_0X4:
             case VM::QEMU_BRAND:
             case VM::BOCHS_CPU:
-            case VM::VPC_BOARD:
             case VM::MAC_MEMSIZE:
             case VM::MAC_IOKIT:
             case VM::IOREG_GREP:
@@ -558,13 +557,13 @@ void replace(std::string &text, const std::string &original, const std::string &
     }
 }
 
-bool is_vm_brand_multiple(const std::string_view vm_brand) {
+bool is_vm_brand_multiple(const std::string& vm_brand) {
     return (vm_brand.find(" or ") != std::string::npos);
 }
 
 
 
-std::string vm_description(const std::string_view vm_brand) {
+std::string vm_description(const std::string& vm_brand) {
 
     // if there's multiple brands, return null
     if (is_vm_brand_multiple(vm_brand)) {
@@ -634,8 +633,7 @@ std::string vm_description(const std::string_view vm_brand) {
         { VM::brands::NULL_BRAND, "" }
     };
 
-    auto it = description_table.find(vm_brand.data());
-
+    std::map<std::string, const char*>::const_iterator it = description_table.find(vm_brand);
     if (it != description_table.end()) {
         return it->second;
     }
@@ -885,7 +883,6 @@ void general() {
     checker(VM::LOADED_DLLS, "loaded DLLs");
     checker(VM::QEMU_BRAND, "QEMU CPU brand");
     checker(VM::BOCHS_CPU, "BOCHS CPU techniques");
-    checker(VM::VPC_BOARD, "VirtualPC motherboard");
     checker(VM::BIOS_SERIAL, "BIOS serial number");
     checker(VM::MSSMBIOS, "MSSMBIOS");
     checker(VM::MAC_MEMSIZE, "MacOS hw.memsize");
@@ -905,7 +902,6 @@ void general() {
     checker(VM::OFFSEC_SGDT, "Offensive Security SGDT");
     checker(VM::OFFSEC_SLDT, "Offensive Security SLDT");
     checker(VM::VPC_SIDT, "VirtualPC SIDT");
-    checker(VM::HYPERV_BOARD, "Hyper-V motherboard");
     checker(VM::VMWARE_IOMEM, "/proc/iomem file");
     checker(VM::VMWARE_IOPORTS, "/proc/ioports file");
     checker(VM::VMWARE_SCSI, "/proc/scsi/scsi file");
@@ -971,6 +967,7 @@ void general() {
 	checker(VM::SYS_QEMU, "QEMU in /sys");
 	checker(VM::LSHW_QEMU, "QEMU in lshw output");
     checker(VM::VIRTUAL_PROCESSORS, "virtual processors");
+    checker(VM::MOTHERBOARD_PRODUCT, "motherboard product");
     // ADD NEW TECHNIQUE CHECKER HERE
 
     std::printf("\n");


### PR DESCRIPTION
Added motherboard_product technique to replace old motherboard techniques (25 of score)
Added VIRTUAL_PROCESSORS to the Windows list technique
Added compatibility for x64 bits to the virtual_processors technique

Reduced physical port connectors score to 10 as previously discussed
Removed VPC_board and hyperv_board technique, they are not reliable because Microsoft motherboard exists

Fixed Hyper-X detecting Microsoft motherboards as Hyper-V VMs
Fixed Physical port connectors technique from flagging Surface Pro devices
Fixed GetThreadsUsingWMI returning an incorrect value in case of failure
Fixed audio_devices using a different WMI threading mode than the rest of techniques

Improved WMI wrapper to handle multiple WMI initialization modes, previously it was returning an error if WMI was already initialized with another threading mode.
Improved every technique that uses WMI to avoid WMI reinitialization, improving speed

Changed VM brand description functions in CLI to be compatible with C++ 11 (string_view removed from function parameter)