### PR TITLE
hyper-v and amd_sev fix

### DIFF
--- a/docs/documentation.md
+++ b/docs/documentation.md
@@ -371,7 +371,7 @@ VMAware provides a convenient way to not only check for VMs, but also have the f
 | `VM::QEMU_BRAND` | Match for QEMU CPU brands with "QEMU Virtual CPU" string |  | 100% |  |  |  |  |
 | `VM::BOCHS_CPU` | Check for various Bochs-related emulation oversights through CPU checks |  | 95% |  |  |  |  |
 | `VM::BIOS_SERIAL` | Check if the BIOS serial is valid (null = VM) | Windows | 60% |  |  |  |  |
-| `VM::MSSMBIOS` | Check MSSMBIOS registry for VM-specific strings | Windows | 75% |  |  |  |  |
+| `VM::MSSMBIOS` | Check MSSMBIOS registry for VM-specific strings | Windows | 85% |  |  |  |  |
 | `VM::MAC_MEMSIZE` | Check if memory is too low for MacOS system | MacOS | 30% |  |  |  |  |
 | `VM::MAC_IOKIT` | Check MacOS' IO kit registry for VM-specific strings | MacOS | 80% |  |  |  |  |
 | `VM::IOREG_GREP` | Check for VM-strings in ioreg commands for MacOS | MacOS | 75% |  |  |  |  |
@@ -439,7 +439,7 @@ VMAware provides a convenient way to not only check for VMs, but also have the f
 | `VM::VM_DEVICES` | Check for VM-specific devices | Windows | 45% |  |  |  |  |
 | `VM::VMWARE_MEMORY` | Check for VMware-specific memory traces in certain processes | Windows | 50% |  |  |  |  |
 | `VM::IDT_GDT_MISMATCH` | Check if the IDT and GDT limit addresses mismatch between different CPU cores | Windows | 25% |  |  |  |  |
-| `VM::PROCESSOR_NUMBER` | Check for number of processors | Windows | 25% |  |  |  |  |
+| `VM::PROCESSOR_NUMBER` | Check for number of processors | Windows | 50% |  |  |  |  |
 | `VM::NUMBER_OF_CORES` | Check for number of cores | Windows | 50% |  |  |  |  |
 | `VM::WMI_MODEL` | Check for device's model using WMI | Windows | 100% |  |  |  |  |
 | `VM::WMI_MANUFACTURER` | Check for device's manufacturer using WMI | Windows | 100% |  |  |  |  |
@@ -456,7 +456,7 @@ VMAware provides a convenient way to not only check for VMs, but also have the f
 | `VM::MOTHERBOARD_PRODUCT` | Check if the motherboard product string matches "Virtual Machine" | Windows | 50% |  |  |  |  |
 | `VM::HYPERV_QUERY` | Checks if a call to NtQuerySystemInformation with the 0x9f leaf fills a _SYSTEM_HYPERVISOR_DETAIL_INFORMATION structure | Windows | 50% |  |  |  |  |
 | `VM::BAD_POOLS` | Checks for system pools allocated by hypervisors | Windows | 80% |  |  |  |  |
-| `VM::AMD_SEV` | Check for AMD-SEV MSR running on the system |  | 50% | Admin |  |  |  |
+| `VM::AMD_SEV` | Check for AMD-SEV MSR running on the system | Linux and MacOS | 50% | Admin |  |  |  |
 <!-- ADD DETAILS HERE -->
 
 <br>

--- a/src/cli.cpp
+++ b/src/cli.cpp
@@ -473,7 +473,6 @@ bool is_unsupported(VM::enum_flags flag) {
             case VM::MOTHERBOARD_PRODUCT:
             case VM::HYPERV_QUERY:
             case VM::BAD_POOLS:
-			case VM::AMD_SEV:
             // ADD WINDOWS FLAG
             return false;
             default: return true;


### PR DESCRIPTION
# Score changes
Increased MSSMBIOS score from 75 to 85, to have the same score as ACPI (they get the vm strings from almost the same source)
Increased  PROCESSOR_NUMBER from 25 to 50, a CPU should not have less than 4 threads nowadays

**------------------------------------------------------------------------------------------------------------------------------**
# New detections
Added more detections for VMWare in vm_sidt technique
Added more detections for several VM brands in ACPI technique
Added brand return in gpu names technique, this means that now it will not return true but return the specific brand detected

**------------------------------------------------------------------------------------------------------------------------------**
# Compatibility changes
Made AMD_SEV technique compatible with Linux and MacOS only

**------------------------------------------------------------------------------------------------------------------------------**
# Improvements to existent techniques
Improved Hyper-X to also account for is_root_partition to determine if we're running under a Hyper-V VM, if eax == 11 fails
Improved tabulation in hypervisor_str technique

**------------------------------------------------------------------------------------------------------------------------------**
# Removed
Removed get_windows_version_backup utility function, the reason is because that module returns the build version based on the NT kernel version. Windows 11 and 10 share the same NT version (10), which means the technique that use them, such as VBOX_DEFAULT, were checking for virtual box default specs for windows 10 instead of windows 11.

**------------------------------------------------------------------------------------------------------------------------------**
# Solved bugs
Fixed an important problem where in every VM we were returning "Hyper-V OR (correct vm brand) in cpuid_signature technique. This happened because if hyper_x returned false (meaning it didn't detect a baremetal machine), the technique would add a brand if it detects the Hyper-V hypervisor in the cpuid signature, which is wrong, as Type 2 hypervisors running Windows will run under Hyper-V nested virtualization, 