### PR TITLE
updated VM::VM_MEMORY

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -20,7 +20,6 @@
 - [ ] implement techniques from here https://www.cyberciti.biz/faq/linux-determine-virtualization-technology-command/
 - [ ] implement techniques from virt-what
 - [ ] https://cloud.google.com/compute/docs/instances/detect-compute-engine
-- [ ] add WMI memo line details in sections category of the banner 
 - [ ] update the updater.py script and fix it
 
 # Distant plans


### PR DESCRIPTION
Updated TODO.md

VM::MEMORY -> Implemented a trie with failure links for efficient multipattern search using the Aho-Corasick algorithm, reducing the buffer processing to a single pass. The technique will also skip memory regions and buffers too small to contain any pattern to reduce unnecesary reads. std::optional was replaced with const char*& result so that suitable conversions when returning false or true in the function can be found by compilers (especially Clang)

util::SetDebugPrivilege -> modified so that it can also disable debugging privileges for the current process. VMAware will now check if the token was already enabled by the program using our lib to determine if the debug privilege should be modified