### PR TITLE
Changed scores in thread mismatch techniques to 95

### DIFF
--- a/docs/documentation.md
+++ b/docs/documentation.md
@@ -392,8 +392,8 @@ VMAware provides a convenient way to not only check for VMs, but also have the f
 | `VM::SMSW` | Check for SMSW assembly instruction technique | Windows | 30% |  |  | 32-bit |  |
 | `VM::MUTEX` | Check for mutex strings of VM brands | Windows | 85% |  |  |  |  |
 | `VM::ODD_CPU_THREADS` | Check for odd CPU threads, usually a sign of modification through VM setting because 99% of CPUs have even numbers of threads |  | 80% |  |  |  |  |
-| `VM::INTEL_THREAD_MISMATCH` | Check for Intel CPU thread count database if it matches the system's thread count |  | 150% |  |  |  |  |
-| `VM::XEON_THREAD_MISMATCH` | Same as above, but for Xeon Intel CPUs |  | 100% |  |  |  |  |
+| `VM::INTEL_THREAD_MISMATCH` | Check for Intel CPU thread count database if it matches the system's thread count |  | 95% |  |  |  |  |
+| `VM::XEON_THREAD_MISMATCH` | Same as above, but for Xeon Intel CPUs |  | 95% |  |  |  |  |
 | `VM::NETTITUDE_VM_MEMORY` | Check for memory regions to detect VM-specific brands | Windows | 100% | |  |  |  |
 | `VM::CPUID_BITSET` |  Check for CPUID technique by checking whether all the bits equate to more than 4000 |  | 25% |  |  |  |  |
 | `VM::CUCKOO_DIR` | Check for cuckoo directory using crt and WIN API directory functions | Windows | 30% |  |  |  |  |
@@ -429,7 +429,7 @@ VMAware provides a convenient way to not only check for VMs, but also have the f
 | `VM::GPU_NAME` | Check for VM specific device names in GPUs | Windows | 100% |  |  |  |  |
 | `VM::VM_DEVICES` | Check for VM-specific devices | Windows | 45% |  |  |  |  |
 | `VM::VM_MEMORY` | Check for specific VM memory traces in certain processes | Windows | 65% |  |  |  |  |
-| `VM::IDT_GDT_MISMATCH` | Check if the IDT and GDT limit addresses mismatch between different CPU cores | Windows | 50% | Admin |  |  |  |
+| `VM::IDT_GDT_MISMATCH` | Check if the IDT and GDT base virtual addresses mismatch between different CPU cores when called from usermode under a root partition | Windows | 50% |  |  |  |  |
 | `VM::PROCESSOR_NUMBER` | Check for number of processors | Windows | 50% |  |  |  |  |
 | `VM::NUMBER_OF_CORES` | Check for number of cores | Windows | 50% |  |  |  |  |
 | `VM::ACPI_TEMPERATURE` | Check for device's temperature | Windows | 25% |  |  |  |  |
@@ -440,7 +440,7 @@ VMAware provides a convenient way to not only check for VMs, but also have the f
 | `VM::HYPERV_QUERY` | Check if a call to NtQuerySystemInformation with the 0x9f leaf fills a _SYSTEM_HYPERVISOR_DETAIL_INFORMATION structure | Windows | 100% |  |  |  |  |
 | `VM::BAD_POOLS` | Check for system pools allocated by hypervisors | Windows | 80% |  |  |  |  |
 | `VM::AMD_SEV` | Check for AMD-SEV MSR running on the system | Linux and MacOS | 50% | Admin |  |  |  |
-| `VM::AMD_THREAD_MISMATCH` | Check for AMD CPU thread count database if it matches the system's thread count |  | 100% |  |  |  |  |
+| `VM::AMD_THREAD_MISMATCH` | Check for AMD CPU thread count database if it matches the system's thread count |  | 95% |  |  |  |  |
 | `VM::NATIVE_VHD` | Checks if the OS was booted from a VHD container |  | 100% |  |  |  |  |
 | `VM::NATIVE_VHD` | Check for OS being booted from a VHD container | Windows | 100% |  |  |  |  |
 | `VM::VIRTUAL_REGISTRY` | Check for particular object directory which is present in Sandboxie virtual environment but not in usual host systems | Windows | 65% |  |  |  |  |


### PR DESCRIPTION
The score was modified to 95, so that at least 1-2 more techniques must be flagged to conclude that the system is running on a VM

The mechanism to detect thread and cpu data tampering by cross-referencing was removed until I confirm it actually works against hardeners, likely not

People can disable logical or physical cores because/to:

1. Redistribute power/thermal headroom to achieve higher clock speeds on fewer cores. When overclocking, having fewer active cores could allow higher clock speeds on the remaining cores since the power and thermal headroom is redistributed. Enthusiasts might do this to push performance on specific cores for tasks that don't need many cores but benefit from higher clock speeds.
2. Prioritize performance for tasks (e.g., legacy software, older games) that benefit from fewer, faster cores.
3. Disable hyper-threading to reduce contention in high-performance computing or latency-sensitive tasks.
4. Mitigate overheating in systems with inadequate cooling.
5. Extend battery life in portable devices or reduce power consumption in energy-sensitive environments.
6. Lower heat output to minimize fan noise (e.g., in recording studios, or simply because it annoys the user).
7. Compatibility with older applications designed for single-core CPUs.
8. Work around instability caused by multi-core-aware drivers or BIOS bugs.
9. Stabilize systems with insufficient power delivery or motherboard support for all cores.
10. **Niche case:** Identify faulty cores or diagnose instability caused by specific cores, simplifying testing of multi-threaded applications by forcing fewer active threads, debugging hypervisor/kernel/HAL issues.
11. Reduce attack surfaces for certain side-channel exploits by limiting active cores. For instance, Hyper-Threading being disabled is needed by Hyper-V to apply certain mitigations.
12. **Niche case:** Comply with per-core licensing models (e.g., Windows Server, enterprise software) to reduce costs in a company, or to meet regulatory requirements for energy efficiency. Some OS licenses are tied to the number of cores. For example, Windows Server editions have licensing based on cores.
13. Ensure predictable performance in industrial/embedded systems by limiting core usage.
14. **Niche case:** Simulate different hardware configurations for performance analysis, the user forgets to change the configuration back, and get flagged for VM
15. **Niche case:** Study CPU architecture, parallel processing, or thermal behavior by manipulating core availability, the user forgets to change the configuration back, and get flagged for VM
16. Reduce thermal stress to potentially extend CPU lifespan (though less common with modern CPUs).
17. **Very niche case:** Minimize electromagnetic interference in sensitive environments (e.g., laboratories, hospitals...).
18. Performance benefits in gaming applications that benefits from specific cores that have more types of cache.

