### PR TITLE
added detections for Hyper-V Enlightenments

### DIFF
--- a/README.md
+++ b/README.md
@@ -238,7 +238,7 @@ You can view the full docs [here](docs/documentation.md). All the details such a
 
 > I would've made it strictly MIT so proprietary software can make use of the library, but some of the techniques employed are from GPL projects, and I have no choice but to use the same license for legal reasons. 
 > 
-> This gave me an idea to make an MIT version without all of the GPL code so it can also be used without forcing your code to be open source. It should be noted that the MIT version removes <b>7</b> techniques out of 117 (as of 2.0 version), and the lesser the number of techniques, the less accurate the overall result might be.
+> This gave me an idea to make an MIT version without all of the GPL code so it can also be used without forcing your code to be open source. It should be noted that the MIT version removes <b>7</b> techniques out of 116 (as of 2.0 version), and the lesser the number of techniques, the less accurate the overall result might be.
 
 </details>
 

--- a/docs/documentation.md
+++ b/docs/documentation.md
@@ -332,7 +332,7 @@ VMAware provides a convenient way to not only check for VMs, but also have the f
 
 | Flag alias | Description | Cross-platform? (empty = yes) | Certainty | Admin? | GPL-3.0? | 32-bit only? | Notes |
 | ---------- | ----------- | ----------------------------- | --------- | ------ | -------- | ------------ | ----- |
-| `VM::VMID` | Check CPUID output of manufacturer ID for known VMs/hypervisors at leaf 0 |  | 100% |  |  |  |  |
+| `VM::VMID` | Check CPUID output of manufacturer ID for known VMs/hypervisors at leaf 0 and 0x40000000-0x40000100 |  | 100% |  |  |  |  |
 | `VM::CPU_BRAND` | Check if CPU brand model contains any VM-specific string snippets |  | 50% |  |  |  |  |  |
 | `VM::HYPERVISOR_BIT` | Check if hypervisor feature bit in CPUID eax bit 31 is enabled (always false for physical CPUs) |  | 100% |  |  |  |  |
 | `VM::HYPERVISOR_STR` | Check for hypervisor brand string length (would be around 2 characters in a host machine) |  | 75% |  |  |  |  |
@@ -365,7 +365,6 @@ VMAware provides a convenient way to not only check for VMs, but also have the f
 | `VM::VM_PROCESSES` | Check for any VM processes that are active | Windows | 15% |  |  |  |  |
 | `VM::LINUX_USER_HOST` | Check for default VM username and hostname for linux | Linux | 10% |  |  |  |  |
 | `VM::GAMARUE` | Check for Gamarue ransomware technique which compares VM-specific Window product IDs | Windows | 10% |  |  |  |  |
-| `VM::VMID_0X4` | Check if the CPU manufacturer ID matches that of a VM brand with leaf 0x40000000 |  | 100% |  |  |  |  |
 | `VM::BOCHS_CPU` | Check for various Bochs-related emulation oversights through CPU checks |  | 100% |  |  |  |  |
 | `VM::MSSMBIOS` | Check MSSMBIOS registry for VM-specific signatures | Windows | 100% |  |  |  |  |
 | `VM::MAC_MEMSIZE` | Check if memory is too low for MacOS system | MacOS | 15% |  |  |  |  |

--- a/src/README.md
+++ b/src/README.md
@@ -2,7 +2,7 @@
 |------|---------|
 | `cli.cpp`  | Entire CLI tool code |
 | `vmaware.hpp` | Official and original library header in GPL-3.0, most likely what you're looking for. |
-| `vmaware_MIT.hpp` | Same as above but in MIT. But this removes 7 techniques out of 117 |
+| `vmaware_MIT.hpp` | Same as above but in MIT. But this removes 7 techniques out of 116 |
 
 
 > [!IMPORTANT]

--- a/src/cli.cpp
+++ b/src/cli.cpp
@@ -352,7 +352,6 @@ bool is_unsupported(VM::enum_flags flag) {
             case VM::DISK_SIZE:
             case VM::VBOX_DEFAULT:
             case VM::LINUX_USER_HOST:
-            case VM::VMID_0X4:
             case VM::BOCHS_CPU:
             case VM::QEMU_GA:
             case VM::SIDT:
@@ -420,7 +419,6 @@ bool is_unsupported(VM::enum_flags flag) {
             case VM::QEMU_DIR:
             case VM::VM_PROCESSES:
             case VM::GAMARUE:
-            case VM::VMID_0X4:
             case VM::BOCHS_CPU:
             case VM::MSSMBIOS:
             case VM::HKLM_REGISTRIES:
@@ -490,7 +488,6 @@ bool is_unsupported(VM::enum_flags flag) {
             case VM::TIMER:
             case VM::THREADCOUNT:
             case VM::HWMODEL:
-            case VM::VMID_0X4:
             case VM::BOCHS_CPU:
             case VM::MAC_MEMSIZE:
             case VM::MAC_IOKIT:
@@ -911,7 +908,6 @@ void general() {
     checker(VM::VM_PROCESSES, "VM processes");
     checker(VM::LINUX_USER_HOST, "default Linux user/host");
     checker(VM::GAMARUE, "gamarue ransomware technique");
-    checker(VM::VMID_0X4, "0x4 leaf of VMID");
     checker(VM::BOCHS_CPU, "BOCHS CPU techniques");
     checker(VM::MSSMBIOS, "MSSMBIOS data");
     checker(VM::MAC_MEMSIZE, "MacOS hw.memsize");


### PR DESCRIPTION
> added detections for QEMU Hyper-V Enlightenments in Hyper-X mechanism

> improved util::vmid_template, same as the previous functions but now the if statements are rearranged so that known brands are checked first to return faster, and the technique_name is not passed as a parameter anymore (its calculated at compile-time if debug builds are enabled for performance benefits)

> improved util::cpu_manufacturer, it wont generate all the permutations, it will generate only the correct permutation depending on the leaf for better performance

> improved VM::VMID, it will check for new leafs now

> Merged VM::VMID_0x4 into VM::VMID for better readability (and a 'jmp' instruction less when compiling heh)