### PR TITLE
Add checks for ACPI table strings

### DIFF
--- a/docs/documentation.md
+++ b/docs/documentation.md
@@ -534,6 +534,9 @@ VMAware provides a convenient way to not only check for VMs, but also have the f
 | `VM::OSXSAVE` | Check if running xgetbv in the XCR0 extended feature register triggers an exception | Windows | 50% |  |  |  |  |
 | `VM::NSJAIL_PID` | Check if process status matches with nsjail patterns with PID anomalies | Linux | 75% |  |  |  |  |
 | `VM::PCI_VM` | Check for PCIe bridge names for known VM keywords and brands | Linux | 100% |  |  |  |  |
+| `VM::BOCHS_VM_STRINGS` | Check ACPI tables for BOCHS and BXPC strings | Windows, Linux | 100% | Admin |  |  |  |
+| `VM::VBOX_VM_STRINGS` | Check ACPI tables for VBOX, vbox and VirtualBox strings | Windows, Linux | 100% | Admin |  |  |  |
+| `VM::WAET_VM_STRINGS` | Check ACPI tables for WAET string | Windows | 100% |  |  |  |  |
 <!-- ADD TECHNIQUE DETAILS HERE -->
 
 <br>

--- a/src/cli.cpp
+++ b/src/cli.cpp
@@ -389,6 +389,8 @@ bool is_unsupported(VM::enum_flags flag) {
             case VM::UNKNOWN_MANUFACTURER:
             case VM::NSJAIL_PID:
             case VM::PCI_VM:
+            case VM::BOCHS_ACPI_STRINGS:
+            case VM::VBOX_ACPI_STRINGS:
             // ADD LINUX FLAG
             return false;
             default: return true;
@@ -469,6 +471,9 @@ bool is_unsupported(VM::enum_flags flag) {
             case VM::FIRMWARE:
             case VM::UNKNOWN_MANUFACTURER:
             case VM::OSXSAVE:
+            case VM::BOCHS_ACPI_STRINGS:
+            case VM::VBOX_ACPI_STRINGS:
+            case VM::WAET_ACPI_STRINGS:
             // ADD WINDOWS FLAG
             return false;
             default: return true;
@@ -994,6 +999,9 @@ void general() {
     checker(VM::OSXSAVE, "xgetbv");
     checker(VM::NSJAIL_PID, "nsjail PID");
     checker(VM::PCI_VM, "PCIe bridge ports");
+    checker(VM::BOCHS_ACPI_STRINGS, "Bochs ACPI strings");
+    checker(VM::VBOX_ACPI_STRINGS, "VirtualBox ACPI strings");
+    checker(VM::WAET_ACPI_STRINGS, "WAET ACPI presence");
     // ADD NEW TECHNIQUE CHECKER HERE
 
     std::printf("\n");

--- a/src/vmaware_MIT.hpp
+++ b/src/vmaware_MIT.hpp
@@ -677,6 +677,9 @@ public:
         OSXSAVE,
         NSJAIL_PID,
         PCI_VM,
+        BOCHS_ACPI_STRINGS,
+        VBOX_ACPI_STRINGS,
+        WAET_ACPI_STRINGS,
         // ADD NEW TECHNIQUE ENUM NAME HERE
 
         // special flags, different to settings
@@ -9848,6 +9851,175 @@ private: // START OF PRIVATE VM DETECTION TECHNIQUE DEFINITIONS
 #endif
     }
 
+    [[nodiscard]] static bool _acpi_strings(const char* string) {
+#if (APPLE)
+        return false;
+#elif (WINDOWS)
+        PDWORD table_names = static_cast<PDWORD>(calloc(0x1000, 1));
+
+        if (table_names == NULL) {
+            debug("ACPI_STRINGS: failed to allocate memory for table_names");
+            return false;
+        }
+
+        DWORD sig = static_cast<DWORD>('ACPI');
+        DWORD table_size = EnumSystemFirmwareTables(sig, table_names, 0x1000);
+
+        if (table_size < 4) {
+            debug("ACPI_STRINGS: no ACPI tables found");
+            return true;
+        }
+
+        for (auto i = 0; i < table_size / 4; ++i) {
+            DWORD table_size = 0;
+            PBYTE firmware_table = static_cast<PBYTE>(calloc(0x1000, 1));
+
+            if (firmware_table == NULL) {
+                debug("ACPI_STRINGS: failed to allocate memory for firmware_table");
+                return false;
+            }
+
+            DWORD actual_table_size = GetSystemFirmwareTable(sig, table_names[i], firmware_table, table_size);
+
+            if (actual_table_size == 0) {
+                debug("ACPI_STRINGS: actual_table_size is 0");
+                free(firmware_table);
+                return false;
+            }
+            else if (actual_table_size > table_size) {
+                PBYTE firmware_table_realloc = static_cast<PBYTE>(realloc(firmware_table, actual_table_size));
+
+                if (firmware_table_realloc == NULL) {
+                    debug("ACPI_STRINGS: failed to allocate memory for firmware_table_realloc");
+                    free(firmware_table);
+                    return false;
+                }
+
+                firmware_table = firmware_table_realloc;
+                table_size = actual_table_size;
+
+                actual_table_size = GetSystemFirmwareTable(sig, table_names[i], firmware_table, table_size);
+
+                if (actual_table_size == 0) {
+                    debug("ACPI_STRINGS: actual_table_size is 0");
+                    free(firmware_table);
+                    return false;
+                }
+
+                table_size = actual_table_size;
+            }
+
+            auto str_len = strlen((char*)string);
+            for (auto j = 0; j < table_size; ++j) {
+                if (memcmp(firmware_table + j, (void*)string, str_len) == 0) {
+                    debug("ACPI_STRINGS: found ", string);
+                    free(firmware_table);
+                    return true;
+                };
+            }
+
+            free(firmware_table);
+        }
+#elif (LINUX)
+        DIR* dir = opendir("/sys/firmware/acpi/tables/");
+        if (!dir) {
+            debug("ACPI_STRINGS: could not open ACPI tables directory");
+            return false;
+        }
+
+        auto str_len = strlen(string);
+        struct dirent* entry;
+
+        while ((entry = readdir(dir)) != NULL) {
+            // Skip "." and ".." entries
+            if (strcmp(entry->d_name, ".") == 0 || strcmp(entry->d_name, "..") == 0) {
+                continue;
+            }
+
+            // Build full path to the ACPI table
+            char path[PATH_MAX];
+            snprintf(path, sizeof(path), "/sys/firmware/acpi/tables/%s", entry->d_name);
+
+            struct stat statbuf;
+            if (stat(path, &statbuf) != 0) {
+                debug("ACPI_STRINGS: skipped /sys/firmware/acpi/tables/", entry->d_name);
+                continue;
+            }
+            
+            if (S_ISDIR(statbuf.st_mode)) {
+                debug("ACPI_STRINGS: skipped /sys/firmware/acpi/tables/", entry->d_name);
+                continue;
+            }
+
+            // Open the table file
+            FILE* file = fopen(path, "rb");
+            if (!file) {
+                debug("ACPI_STRINGS: could not open ACPI table ", entry->d_name);
+                continue;
+            }
+
+            // Get file size
+            fseek(file, 0, SEEK_END);
+            long file_size = ftell(file);
+            fseek(file, 0, SEEK_SET);
+
+            // Read file content
+            char* buffer = static_cast<char*>(malloc(file_size));
+            if (!buffer) {
+                debug("ACPI_STRINGS: failed to allocate memory for buffer");
+                fclose(file);
+                continue;
+            }
+
+            if (fread(buffer, 1, file_size, file) != static_cast<size_t>(file_size)) {
+                debug("ACPI_STRINGS: failed to read ACPI table ", entry->d_name);
+                free(buffer);
+                fclose(file);
+                continue;
+            }
+
+            // Search for the string in the table
+            for (long j = 0; j < file_size - str_len; ++j) {
+                if (memcmp(buffer + j, string, str_len) == 0) {
+                    debug("ACPI_STRINGS: found ", string, " in ", entry->d_name);
+                    free(buffer);
+                    fclose(file);
+                    closedir(dir);
+                    return true;
+                }
+            }
+
+            free(buffer);
+            fclose(file);
+        }
+
+        closedir(dir);
+#endif
+        return false;
+    }
+
+    [[nodiscard]] static bool bochs_acpi_strings() {
+        if (_acpi_strings("BOCHS") || _acpi_strings("BXPC")) {
+            return core::add(brands::BOCHS);
+        }
+        else {
+            return false;
+        }
+    }
+
+    [[nodiscard]] static bool vbox_acpi_strings() {
+        if (_acpi_strings("VBOX") || _acpi_strings("vbox") || _acpi_strings("VirtualBox")) {
+            return core::add(brands::VBOX);
+        }
+        else {
+            return false;
+        }
+    }
+
+    [[nodiscard]] static bool waet_acpi_strings() {
+        return _acpi_strings("WAET");
+    }
+
     // ADD NEW TECHNIQUE FUNCTION HERE
 
 
@@ -11700,7 +11872,11 @@ std::pair<VM::enum_flags, VM::core::technique> VM::core::technique_list[] = {
     std::make_pair(VM::UNKNOWN_MANUFACTURER, VM::core::technique(50, VM::unknown_manufacturer)),
     std::make_pair(VM::OSXSAVE, VM::core::technique(50, VM::osxsave)),
     std::make_pair(VM::NSJAIL_PID, VM::core::technique(75, VM::nsjail_proc_id)),
-    std::make_pair(VM::PCI_VM, VM::core::technique(100, VM::lspci))
+    std::make_pair(VM::PCI_VM, VM::core::technique(100, VM::lspci)),
+    std::make_pair(VM::PCI_VM, VM::core::technique(100, VM::lspci)),
+    std::make_pair(VM::BOCHS_ACPI_STRINGS, VM::core::technique(100, VM::bochs_acpi_strings)),
+    std::make_pair(VM::VBOX_ACPI_STRINGS, VM::core::technique(100, VM::vbox_acpi_strings)),
+    std::make_pair(VM::WAET_ACPI_STRINGS, VM::core::technique(100, VM::waet_acpi_strings)),
     // ADD NEW TECHNIQUE STRUCTURE HERE
 };
 


### PR DESCRIPTION
#  MAKE SURE TO READ THE CONTRIBUTION GUIDELINES BEFORE CONTINUING!

## What does this PR do?
- [x] Add a new technique
- [ ] Add a new feature
- [ ] Fix bugs
- [ ] Refactoring 
- [ ] Sync between branches
- [ ] Other

## Briefly explain what this PR does:
This PR adds 3 new VM detection checks based on finding known VM strings in ACPI tables
1. Bochs (BOCHS_ACPI_STRINGS)
2. Vbox (VBOX_ACPI_STRINGS)
3. WAET - generic method which finds Windows ACPI Emulated devices Table, see https://download.microsoft.com/download/7/E/7/7E7662CF-CBEA-470B-A97E-CE7CE0D98DC2/WAET.docx
(WAET_ACPI_STRINGS)

Yesterday I found a new VM detection technique - WAET method. Firstly I implemented it for a well-known al-khaser utility, and now I decide to port this functionality to vmaware including other ACPI strings lookups from al-khaser (why not).

Code was added manually because script seems broken or at least I don't understand why my code (specifically modified for this script by code duplication and so on) is injected with compilation errors.

Tested on x86 Windows 11 host & QEMU VM
Tested on x86 Archlinux host
Tested on x86 Ubuntu 22.04 QEMU VM