### PR TITLE
Make sure that the library compiles on Windows when WIN32_LEAN_AND_MEAN is defined

### DIFF
--- a/src/cli.cpp
+++ b/src/cli.cpp
@@ -36,6 +36,7 @@
 
 #if (defined(_MSC_VER) || defined(_WIN32) || defined(_WIN64) || defined(__MINGW32__))
     #define WINDOWS 1
+    #define WIN32_LEAN_AND_MEAN
     #include <windows.h>
 #else
     #define WINDOWS 0

--- a/src/vmaware.hpp
+++ b/src/vmaware.hpp
@@ -351,6 +351,7 @@
 #include <intrin.h>
 #include <tchar.h>
 #include <iphlpapi.h>
+#include <winioctl.h>
 #include <winternl.h>
 #include <winuser.h>
 #include <psapi.h>

--- a/src/vmaware_MIT.hpp
+++ b/src/vmaware_MIT.hpp
@@ -373,6 +373,7 @@
 #include <intrin.h>
 #include <tchar.h>
 #include <iphlpapi.h>
+#include <winioctl.h>
 #include <winternl.h>
 #include <winuser.h>
 #include <psapi.h>


### PR DESCRIPTION
## What does this PR do?
- [x] Other

## Briefly explain what this PR does:

Make sure that the library compiles on Windows when WIN32_LEAN_AND_MEAN is defined.
- Added missing winioctl.h for STORAGE_PROPERTY_QUERY and IOCTL_STORAGE_PROPERTY_QUERY
- CLI now compiles with with WIN32_LEAN_AND_MEAN to make sure this won't break in the future