### PR TITLE
Added ifndef to avoid compilation issue if symbol was already defined before

### DIFF
--- a/src/vmaware.hpp
+++ b/src/vmaware.hpp
@@ -185,7 +185,9 @@
 #pragma once
 
 #if defined(_WIN32) || defined(_WIN64)
+#ifndef WIN32_LEAN_AND_MEAN
 #define WIN32_LEAN_AND_MEAN
+#endif
 #define WINDOWS 1
 #define LINUX 0
 #define APPLE 0

--- a/src/vmaware_MIT.hpp
+++ b/src/vmaware_MIT.hpp
@@ -207,7 +207,9 @@
 #pragma once
 
 #if defined(_WIN32) || defined(_WIN64)
+#ifndef WIN32_LEAN_AND_MEAN
 #define WIN32_LEAN_AND_MEAN
+#endif
 #define WINDOWS 1
 #define LINUX 0
 #define APPLE 0


### PR DESCRIPTION
#  MAKE SURE TO READ THE CONTRIBUTION GUIDELINES BEFORE CONTINUING!

## What does this PR do?
- [ ] Add a new technique
- [ ] Add a new feature
- [x] Fix bugs
- [ ] Refactoring 
- [ ] Sync between branches
- [x] Other

## Briefly explain what this PR does:
Added ifndef to avoid compilation issue if symbol was already defined before

We compile using /D WIN32_LEAN_AND_MEAN

Otherwise we get:
```
error C2220: the following warning is treated as an error
warning C4005: 'WIN32_LEAN_AND_MEAN': macro redefinition
message : 'WIN32_LEAN_AND_MEAN' previously declared on the command line
```