### PR TITLE
removed VM::IDT_GDT_SCAN

### DIFF
--- a/README.md
+++ b/README.md
@@ -239,7 +239,7 @@ You can view the full docs [here](docs/documentation.md). All the details such a
 
 > I would've made it strictly MIT so proprietary software can make use of the library, but some of the techniques employed are from GPL projects, and I have no choice but to use the same license for legal reasons. 
 > 
-> This gave me an idea to make an MIT version without all of the GPL code so it can also be used without forcing your code to be open source. It should be noted that the MIT version removes <b>7</b> techniques out of 118 (as of 2.0 version), and the lesser the number of techniques, the less accurate the overall result might be.
+> This gave me an idea to make an MIT version without all of the GPL code so it can also be used without forcing your code to be open source. It should be noted that the MIT version removes <b>7</b> techniques out of 117 (as of 2.0 version), and the lesser the number of techniques, the less accurate the overall result might be.
 
 </details>
 

--- a/docs/documentation.md
+++ b/docs/documentation.md
@@ -512,7 +512,6 @@ VMAware provides a convenient way to not only check for VMs, but also have the f
 | `VM::GPU_CAPABILITIES` | Check for GPU capabilities related to VMs | Windows | 100% | Admin |  |  | Admin only needed for some heuristics |
 | `VM::GPU_VM_STRINGS` | Check for specific GPU string signatures related to VMs | Windows | 100% |  |  |  | If GPU_CAPABILITIES also flags, the overall score will be 50 instead of 100 |
 | `VM::VM_DEVICES` | Check for VM-specific devices | Windows | 50% |  |  |  |  |
-| `VM::IDT_GDT_SCAN` | Check if the IDT and GDT virtual base addresses are equal across different CPU cores when not running under Hyper-V | Windows | 50% |  |  |  |  |
 | `VM::PROCESSOR_NUMBER` | Check for number of processors | Windows | 50% |  |  |  |  |
 | `VM::NUMBER_OF_CORES` | Check for number of cores | Windows | 50% |  |  |  |  |
 | `VM::ACPI_TEMPERATURE` | Check for device's temperature | Windows | 25% |  |  |  |  |

--- a/src/README.md
+++ b/src/README.md
@@ -2,7 +2,7 @@
 |------|---------|
 | `cli.cpp`  | Entire CLI tool code |
 | `vmaware.hpp` | Official and original library header in GPL-3.0, most likely what you're looking for. |
-| `vmaware_MIT.hpp` | Same as above but in MIT. But this removes 7 techniques out of 118 |
+| `vmaware_MIT.hpp` | Same as above but in MIT. But this removes 7 techniques out of 117 |
 
 <br>
 

--- a/src/cli.cpp
+++ b/src/cli.cpp
@@ -455,7 +455,6 @@ bool is_unsupported(VM::enum_flags flag) {
             case VM::PORT_CONNECTORS:
             case VM::GPU_VM_STRINGS:
             case VM::GPU_CAPABILITIES:
-            case VM::IDT_GDT_SCAN:
             case VM::PROCESSOR_NUMBER:
             case VM::NUMBER_OF_CORES:
             case VM::ACPI_TEMPERATURE:
@@ -972,7 +971,6 @@ void general() {
     checker(VM::PORT_CONNECTORS, "physical connection ports");
     checker(VM::GPU_CAPABILITIES, "GPU capabilities");
     checker(VM::GPU_VM_STRINGS, "GPU strings");
-    checker(VM::IDT_GDT_SCAN, "IDT GDT consistency");
     checker(VM::PROCESSOR_NUMBER, "processor count");
     checker(VM::NUMBER_OF_CORES, "CPU core count");
     checker(VM::ACPI_TEMPERATURE, "thermal devices");

--- a/src/vmaware.hpp
+++ b/src/vmaware.hpp
@@ -646,7 +646,6 @@ public:
         GPU_VM_STRINGS,
         GPU_CAPABILITIES,
         VM_DEVICES,
-        IDT_GDT_SCAN,
         PROCESSOR_NUMBER,
         NUMBER_OF_CORES,
         ACPI_TEMPERATURE,
@@ -7706,7 +7705,7 @@ private: // START OF PRIVATE VM DETECTION TECHNIQUE DEFINITIONS
         const HANDLE handle5 = CreateFileA(("\\\\.\\HGFS"), GENERIC_READ, FILE_SHARE_READ, NULL, OPEN_EXISTING, FILE_ATTRIBUTE_NORMAL, NULL);
         const HANDLE handle6 = CreateFileA(("\\\\.\\pipe\\cuckoo"), GENERIC_READ, FILE_SHARE_READ, NULL, OPEN_EXISTING, FILE_ATTRIBUTE_NORMAL, NULL);
 
-        bool result = false;
+        bool vbox = false;
 
         if (
             (handle1 != INVALID_HANDLE_VALUE) ||
@@ -7714,7 +7713,7 @@ private: // START OF PRIVATE VM DETECTION TECHNIQUE DEFINITIONS
             (handle3 != INVALID_HANDLE_VALUE) ||
             (handle4 != INVALID_HANDLE_VALUE)
            ) {
-            result = true;
+            vbox = true;
         }
 
         CloseHandle(handle1);
@@ -7722,7 +7721,7 @@ private: // START OF PRIVATE VM DETECTION TECHNIQUE DEFINITIONS
         CloseHandle(handle3);
         CloseHandle(handle4);
 
-        if (result) {
+        if (vbox) {
             debug("VM_DEVICES: Detected VBox related device handles");
             return core::add(brands::VBOX);
         }
@@ -7744,98 +7743,6 @@ private: // START OF PRIVATE VM DETECTION TECHNIQUE DEFINITIONS
         return false;
 #endif
     }    
-
-
-    /**
-     * @brief Check if the IDT and GDT virtual base addresses are equal across different CPU cores when not running under Hyper-V
-     * @note  The Windows kernel has different interrupt handlers registered for each CPU core, resulting in different virtual addresses when calling SIDT and SGDT in kernel-mode.
-     *        However, when Windows is running under Hyper-V (in a root partition), the IDT and GDT base address will always be the same across all CPU cores if called from user-mode.
-     *        This kernel address leak prevention measure is done by Hyper-V on purpose and can be abused to detect VMs.
-     * @category Windows, x64
-     * @author Requiem (https://github.com/NotRequiem)
-     * @implements VM::IDT_GDT_SCAN
-     */
-    [[nodiscard]] static bool idt_gdt_scan() {
-#if (!WINDOWS)
-        return false;
-#else
-        // If the system is running under any Hyper-V hypervisor (type 1 or type 2), the IDT and GDT will be equal, as this function is called from user-mode.
-        if (util::hyper_x() != HYPERV_UNKNOWN_VM) {
-            return false;
-        }
-
-        unsigned int num_threads = std::thread::hardware_concurrency();
-
-        uint64_t* gdtResults = new uint64_t[num_threads];
-        uint64_t* idtResults = new uint64_t[num_threads];
-
-        std::vector<std::thread> threads;
-        threads.reserve(num_threads);
-
-        for (unsigned int i = 0; i < num_threads; ++i) {
-            try {
-                threads.emplace_back([i, gdtResults, idtResults]() {
-                    const HANDLE thread = GetCurrentThread();
-                    DWORD_PTR affinity_mask = 1ULL << i;
-                    SetThreadAffinityMask(thread, affinity_mask);
-
-#pragma pack(push, 1)
-                    struct DescriptorTablePointer {
-                        uint16_t limit;
-                        uint64_t base;
-                    };
-#pragma pack(pop)
-
-                    DescriptorTablePointer idtr = {};
-                    DescriptorTablePointer gdtr = {};
-
-#if (CLANG || GCC)
-                    __asm__ volatile("sidt %0" : "=m"(idtr));
-                    __asm__ volatile("sgdt %0" : "=m"(gdtr));
-#else
-                    __sidt(&idtr);
-                    _sgdt(&gdtr);
-#endif
-
-                    gdtResults[i] = gdtr.base;
-                    idtResults[i] = idtr.base;
-                    });
-            }
-            catch (...) {
-                delete[] gdtResults;
-                delete[] idtResults;
-                return false; // umip
-            }
-        }
-
-        for (auto& thread : threads) {
-            thread.join();
-        }
-
-        bool equal = true;
-
-        for (unsigned int i = 1; i < num_threads; ++i) {
-            if (gdtResults[i] != gdtResults[0]) {
-                equal = false;
-                break;
-            }
-        }
-
-        if (equal) {
-            for (unsigned int i = 1; i < num_threads; ++i) {
-                if (idtResults[i] != idtResults[0]) {
-                    equal = false;
-                    break;
-                }
-            }
-        }
-
-        delete[] gdtResults;
-        delete[] idtResults;
-
-        return equal;
-#endif
-    }
 
 
     /**
@@ -7886,12 +7793,14 @@ private: // START OF PRIVATE VM DETECTION TECHNIQUE DEFINITIONS
         while (size > 0) {
             if (ptr->Relationship == RelationProcessorCore) {
                 ++physicalCoreCount;
+                if (physicalCoreCount > 1)
+                    return false;
             }
             size -= ptr->Size;
             ptr = reinterpret_cast<PSYSTEM_LOGICAL_PROCESSOR_INFORMATION_EX>(reinterpret_cast<BYTE*>(ptr) + ptr->Size);
         }
 
-        return (physicalCoreCount < 2);
+        return true;
 #endif
     }
 
@@ -8030,7 +7939,7 @@ private: // START OF PRIVATE VM DETECTION TECHNIQUE DEFINITIONS
     // Disable specific sanitizers for more accurate timing measurements.
     __attribute__((no_sanitize("address", "leak", "thread", "undefined")))
 #endif
-        static bool timer() {
+    static bool timer() {
 #if (ARM || !x86)
         return false;
 #else
@@ -8217,8 +8126,10 @@ private: // START OF PRIVATE VM DETECTION TECHNIQUE DEFINITIONS
         const bool qpcCheck = (dummyTime != 0) && ((cpuIdTime / dummyTime) > qpcRatioThreshold);
 #ifdef __VMAWARE_DEBUG__
         debug("TIMER: QPC check - CPUID: ", cpuIdTime,
-            " ns, Dummy: ", dummyTime,
-            " ns, Ratio: ", (cpuIdTime / dummyTime));
+            " ns, RWB: ", dummyTime,
+            " ns, Ratio: ", (cpuIdTime / dummyTime),
+            " (Threshold: ", qpcRatioThreshold,
+            ')');
 #endif
 
         if (qpcCheck) {
@@ -8243,7 +8154,7 @@ private: // START OF PRIVATE VM DETECTION TECHNIQUE DEFINITIONS
                 __except (GetExceptionCode() == EXCEPTION_ILLEGAL_INSTRUCTION
                     ? EXCEPTION_EXECUTE_HANDLER
                     : EXCEPTION_CONTINUE_SEARCH) {
-                    // // RDTSCP is widely supported on real hardware, most likely VM
+                    // RDTSCP is widely supported on real hardware, most likely VM
                     tscIssueCount++;
                     continue;
                 }
@@ -8255,7 +8166,9 @@ private: // START OF PRIVATE VM DETECTION TECHNIQUE DEFINITIONS
             debug("TIMER: TSC sync check",
                 " - Core1: ", tscCore1,
                 " Core2: ", tscCore2,
-                " Diff: ", tscCore2 - tscCore1);
+                " Diff: ", tscCore2 - tscCore1,
+                " (Threshold: ", tscSyncDiffThreshold,
+                ')');
 #endif
             return (tscIssueCount >= tscIterations / 2);
             }();
@@ -11423,7 +11336,6 @@ public: // START OF PUBLIC FUNCTIONS
             case GPU_VM_STRINGS: return "GPU_STRINGS";
             case GPU_CAPABILITIES: return "GPU_CAPABILITIES";
             case VM_DEVICES: return "VM_DEVICES";
-            case IDT_GDT_SCAN: return "IDT_GDT_SCAN";
             case PROCESSOR_NUMBER: return "PROCESSOR_NUMBER";
             case NUMBER_OF_CORES: return "NUMBER_OF_CORES";
             case ACPI_TEMPERATURE: return "ACPI_TEMPERATURE";
@@ -11986,7 +11898,6 @@ std::pair<VM::enum_flags, VM::core::technique> VM::core::technique_list[] = {
     std::make_pair(VM::GPU_VM_STRINGS, VM::core::technique(100, VM::gpu_vm_strings)),
     std::make_pair(VM::GPU_CAPABILITIES, VM::core::technique(100, VM::gpu_capabilities)),
     std::make_pair(VM::VM_DEVICES, VM::core::technique(50, VM::vm_devices)),
-    std::make_pair(VM::IDT_GDT_SCAN, VM::core::technique(50, VM::idt_gdt_scan)),
     std::make_pair(VM::PROCESSOR_NUMBER, VM::core::technique(50, VM::processor_number)),
     std::make_pair(VM::NUMBER_OF_CORES, VM::core::technique(50, VM::number_of_cores)),
     std::make_pair(VM::ACPI_TEMPERATURE, VM::core::technique(25, VM::acpi_temperature)),

--- a/src/vmaware_MIT.hpp
+++ b/src/vmaware_MIT.hpp
@@ -661,7 +661,6 @@ public:
         GPU_VM_STRINGS,
         GPU_CAPABILITIES,
         VM_DEVICES,
-        IDT_GDT_SCAN,
         PROCESSOR_NUMBER,
         NUMBER_OF_CORES,
         ACPI_TEMPERATURE,
@@ -7511,7 +7510,7 @@ private: // START OF PRIVATE VM DETECTION TECHNIQUE DEFINITIONS
         const HANDLE handle5 = CreateFileA(("\\\\.\\HGFS"), GENERIC_READ, FILE_SHARE_READ, NULL, OPEN_EXISTING, FILE_ATTRIBUTE_NORMAL, NULL);
         const HANDLE handle6 = CreateFileA(("\\\\.\\pipe\\cuckoo"), GENERIC_READ, FILE_SHARE_READ, NULL, OPEN_EXISTING, FILE_ATTRIBUTE_NORMAL, NULL);
 
-        bool result = false;
+        bool vbox = false;
 
         if (
             (handle1 != INVALID_HANDLE_VALUE) ||
@@ -7519,7 +7518,7 @@ private: // START OF PRIVATE VM DETECTION TECHNIQUE DEFINITIONS
             (handle3 != INVALID_HANDLE_VALUE) ||
             (handle4 != INVALID_HANDLE_VALUE)
             ) {
-            result = true;
+            vbox = true;
         }
 
         CloseHandle(handle1);
@@ -7527,7 +7526,7 @@ private: // START OF PRIVATE VM DETECTION TECHNIQUE DEFINITIONS
         CloseHandle(handle3);
         CloseHandle(handle4);
 
-        if (result) {
+        if (vbox) {
             debug("VM_DEVICES: Detected VBox related device handles");
             return core::add(brands::VBOX);
         }
@@ -7547,98 +7546,6 @@ private: // START OF PRIVATE VM DETECTION TECHNIQUE DEFINITIONS
         CloseHandle(handle6);
 
         return false;
-#endif
-    }
-
-
-    /**
-     * @brief Check if the IDT and GDT virtual base addresses are equal across different CPU cores when not running under Hyper-V
-     * @note  The Windows kernel has different interrupt handlers registered for each CPU core, resulting in different virtual addresses when calling SIDT and SGDT in kernel-mode.
-     *        However, when Windows is running under Hyper-V (in a root partition), the IDT and GDT base address will always be the same across all CPU cores if called from user-mode.
-     *        This kernel address leak prevention measure is done by Hyper-V on purpose and can be abused to detect VMs.
-     * @category Windows, x64
-     * @author Requiem (https://github.com/NotRequiem)
-     * @implements VM::IDT_GDT_SCAN
-     */
-    [[nodiscard]] static bool idt_gdt_scan() {
-#if (!WINDOWS)
-        return false;
-#else
-        // If the system is running under any Hyper-V hypervisor (type 1 or type 2), the IDT and GDT will be equal, as this function is called from user-mode.
-        if (util::hyper_x() != HYPERV_UNKNOWN_VM) {
-            return false;
-        }
-
-        unsigned int num_threads = std::thread::hardware_concurrency();
-
-        uint64_t* gdtResults = new uint64_t[num_threads];
-        uint64_t* idtResults = new uint64_t[num_threads];
-
-        std::vector<std::thread> threads;
-        threads.reserve(num_threads);
-
-        for (unsigned int i = 0; i < num_threads; ++i) {
-            try {
-                threads.emplace_back([i, gdtResults, idtResults]() {
-                    const HANDLE thread = GetCurrentThread();
-                    DWORD_PTR affinity_mask = 1ULL << i;
-                    SetThreadAffinityMask(thread, affinity_mask);
-
-#pragma pack(push, 1)
-                    struct DescriptorTablePointer {
-                        uint16_t limit;
-                        uint64_t base;
-                    };
-#pragma pack(pop)
-
-                    DescriptorTablePointer idtr = {};
-                    DescriptorTablePointer gdtr = {};
-
-#if (CLANG || GCC)
-                    __asm__ volatile("sidt %0" : "=m"(idtr));
-                    __asm__ volatile("sgdt %0" : "=m"(gdtr));
-#else
-                    __sidt(&idtr);
-                    _sgdt(&gdtr);
-#endif
-
-                    gdtResults[i] = gdtr.base;
-                    idtResults[i] = idtr.base;
-                    });
-            }
-            catch (...) {
-                delete[] gdtResults;
-                delete[] idtResults;
-                return false; // umip
-            }
-        }
-
-        for (auto& thread : threads) {
-            thread.join();
-        }
-
-        bool equal = true;
-
-        for (unsigned int i = 1; i < num_threads; ++i) {
-            if (gdtResults[i] != gdtResults[0]) {
-                equal = false;
-                break;
-            }
-        }
-
-        if (equal) {
-            for (unsigned int i = 1; i < num_threads; ++i) {
-                if (idtResults[i] != idtResults[0]) {
-                    equal = false;
-                    break;
-                }
-            }
-        }
-
-        delete[] gdtResults;
-        delete[] idtResults;
-
-        return equal;
 #endif
     }
 
@@ -7691,12 +7598,14 @@ private: // START OF PRIVATE VM DETECTION TECHNIQUE DEFINITIONS
         while (size > 0) {
             if (ptr->Relationship == RelationProcessorCore) {
                 ++physicalCoreCount;
+                if (physicalCoreCount > 1)
+                    return false;
             }
             size -= ptr->Size;
             ptr = reinterpret_cast<PSYSTEM_LOGICAL_PROCESSOR_INFORMATION_EX>(reinterpret_cast<BYTE*>(ptr) + ptr->Size);
         }
 
-        return (physicalCoreCount < 2);
+        return true;
 #endif
     }
 
@@ -8022,8 +7931,10 @@ private: // START OF PRIVATE VM DETECTION TECHNIQUE DEFINITIONS
         const bool qpcCheck = (dummyTime != 0) && ((cpuIdTime / dummyTime) > qpcRatioThreshold);
 #ifdef __VMAWARE_DEBUG__
         debug("TIMER: QPC check - CPUID: ", cpuIdTime,
-            " ns, Dummy: ", dummyTime,
-            " ns, Ratio: ", (cpuIdTime / dummyTime));
+            " ns, RWB: ", dummyTime,
+            " ns, Ratio: ", (cpuIdTime / dummyTime),
+            " (Threshold: ", qpcRatioThreshold,
+            ')');
 #endif
 
         if (qpcCheck) {
@@ -8048,7 +7959,7 @@ private: // START OF PRIVATE VM DETECTION TECHNIQUE DEFINITIONS
                 __except (GetExceptionCode() == EXCEPTION_ILLEGAL_INSTRUCTION
                     ? EXCEPTION_EXECUTE_HANDLER
                     : EXCEPTION_CONTINUE_SEARCH) {
-                    // // RDTSCP is widely supported on real hardware, most likely VM
+                    // RDTSCP is widely supported on real hardware, most likely VM
                     tscIssueCount++;
                     continue;
                 }
@@ -8060,7 +7971,9 @@ private: // START OF PRIVATE VM DETECTION TECHNIQUE DEFINITIONS
             debug("TIMER: TSC sync check",
                 " - Core1: ", tscCore1,
                 " Core2: ", tscCore2,
-                " Diff: ", tscCore2 - tscCore1);
+                " Diff: ", tscCore2 - tscCore1,
+                " (Threshold: ", tscSyncDiffThreshold,
+                ')');
 #endif
             return (tscIssueCount >= tscIterations / 2);
             }();
@@ -11239,7 +11152,6 @@ public: // START OF PUBLIC FUNCTIONS
         case GPU_VM_STRINGS: return "GPU_STRINGS";
         case GPU_CAPABILITIES: return "GPU_CAPABILITIES";
         case VM_DEVICES: return "VM_DEVICES";
-        case IDT_GDT_SCAN: return "IDT_GDT_SCAN";
         case PROCESSOR_NUMBER: return "PROCESSOR_NUMBER";
         case NUMBER_OF_CORES: return "NUMBER_OF_CORES";
         case ACPI_TEMPERATURE: return "ACPI_TEMPERATURE";
@@ -11798,7 +11710,6 @@ std::pair<VM::enum_flags, VM::core::technique> VM::core::technique_list[] = {
     std::make_pair(VM::GPU_VM_STRINGS, VM::core::technique(100, VM::gpu_vm_strings)),
     std::make_pair(VM::GPU_CAPABILITIES, VM::core::technique(100, VM::gpu_capabilities)),
     std::make_pair(VM::VM_DEVICES, VM::core::technique(50, VM::vm_devices)),
-    std::make_pair(VM::IDT_GDT_SCAN, VM::core::technique(50, VM::idt_gdt_scan)),
     std::make_pair(VM::PROCESSOR_NUMBER, VM::core::technique(50, VM::processor_number)),
     std::make_pair(VM::NUMBER_OF_CORES, VM::core::technique(50, VM::number_of_cores)),
     std::make_pair(VM::ACPI_TEMPERATURE, VM::core::technique(25, VM::acpi_temperature)),


### PR DESCRIPTION
removed VM::IDT_GDT_SCAN, as kernel leak address prevention for IDT base addresses seems to be only present on Hyper-V, which we were skipping as to not flag normal Windows machines

added the threshold variable in all debug outputs of VM::TIMER

improved speed of physical core count checks