### PR TITLE
removed VM::PROCESSOR_ID

### DIFF
--- a/README.md
+++ b/README.md
@@ -239,7 +239,7 @@ You can view the full docs [here](docs/documentation.md). All the details such a
 
 > I would've made it strictly MIT so proprietary software can make use of the library, but some of the techniques employed are from GPL projects, and I have no choice but to use the same license for legal reasons. 
 > 
-> This gave me an idea to make an MIT version without all of the GPL code so it can also be used without forcing your code to be open source. It should be noted that the MIT version removes <b>7</b> techniques out of 117 (as of 2.0 version), and the lesser the number of techniques, the less accurate the overall result might be.
+> This gave me an idea to make an MIT version without all of the GPL code so it can also be used without forcing your code to be open source. It should be noted that the MIT version removes <b>7</b> techniques out of 116 (as of 2.0 version), and the lesser the number of techniques, the less accurate the overall result might be.
 
 </details>
 

--- a/auxiliary/benchmark.cpp
+++ b/auxiliary/benchmark.cpp
@@ -35,7 +35,7 @@
 
 class VMAwareBenchmark {
 public:
-    static uint64_t get_timestamp() {
+    static inline uint64_t get_timestamp() {
 #if defined(_WIN32)
         LARGE_INTEGER counter;
         QueryPerformanceCounter(&counter);
@@ -51,7 +51,7 @@ public:
 #endif
     }
 
-    static double get_elapsed(uint64_t start, uint64_t end) {
+    static inline double get_elapsed(uint64_t start, uint64_t end) {
 #if defined(_WIN32)
         static LARGE_INTEGER freq;
         QueryPerformanceFrequency(&freq);

--- a/docs/documentation.md
+++ b/docs/documentation.md
@@ -515,7 +515,6 @@ VMAware provides a convenient way to not only check for VMs, but also have the f
 | `VM::PROCESSOR_NUMBER` | Check for number of processors | Windows | 50% |  |  |  |  |
 | `VM::NUMBER_OF_CORES` | Check for number of cores | Windows | 50% |  |  |  |  |
 | `VM::ACPI_TEMPERATURE` | Check for device's temperature | Windows | 25% |  |  |  |  |
-| `VM::PROCESSOR_ID` | Check if any processor has an empty Processor ID using SMBIOS data | Windows | 25% |  |  |  |  |
 | `VM::SYS_QEMU` | Check for existence of "qemu_fw_cfg" directories within /sys/module and /sys/firmware | Linux | 70% |  |  |  |  |
 | `VM::LSHW_QEMU` | Check for QEMU string instances with lshw command | Linux | 80% |  |  |  |  |
 | `VM::VIRTUAL_PROCESSORS` | Check if the number of virtual and logical processors are reported correctly by the system | Windows | 50% |  |  |  |  |

--- a/src/README.md
+++ b/src/README.md
@@ -2,7 +2,7 @@
 |------|---------|
 | `cli.cpp`  | Entire CLI tool code |
 | `vmaware.hpp` | Official and original library header in GPL-3.0, most likely what you're looking for. |
-| `vmaware_MIT.hpp` | Same as above but in MIT. But this removes 7 techniques out of 117 |
+| `vmaware_MIT.hpp` | Same as above but in MIT. But this removes 7 techniques out of 116 |
 
 <br>
 

--- a/src/cli.cpp
+++ b/src/cli.cpp
@@ -458,7 +458,6 @@ bool is_unsupported(VM::enum_flags flag) {
             case VM::PROCESSOR_NUMBER:
             case VM::NUMBER_OF_CORES:
             case VM::ACPI_TEMPERATURE:
-            case VM::PROCESSOR_ID:
             case VM::POWER_CAPABILITIES:
             case VM::SETUPAPI_DISK: 
             case VM::VIRTUAL_PROCESSORS:
@@ -974,7 +973,6 @@ void general() {
     checker(VM::PROCESSOR_NUMBER, "processor count");
     checker(VM::NUMBER_OF_CORES, "CPU core count");
     checker(VM::ACPI_TEMPERATURE, "thermal devices");
-    checker(VM::PROCESSOR_ID, "processor ID");
     checker(VM::POWER_CAPABILITIES, "Power capabilities");
     checker(VM::SETUPAPI_DISK, "SETUPDI diskdrive");
     checker(VM::SYS_QEMU, "QEMU in /sys");

--- a/src/vmaware.hpp
+++ b/src/vmaware.hpp
@@ -362,15 +362,10 @@
 #include <psapi.h>
 #include <shlwapi.h>
 #include <shlobj_core.h>
-#include <dshow.h>
-#include <io.h>
 #include <winspool.h>
 #include <powerbase.h>
 #include <setupapi.h>
-#include <mmdeviceapi.h>
-#include <Functiondiscoverykeys_devpkey.h>
 #include <mmsystem.h>
-#include <queue>
 #include <dxgi.h>
 #include <d3d9.h>
 
@@ -649,7 +644,6 @@ public:
         PROCESSOR_NUMBER,
         NUMBER_OF_CORES,
         ACPI_TEMPERATURE,
-        PROCESSOR_ID,
         SYS_QEMU,
         LSHW_QEMU,
         VIRTUAL_PROCESSORS,
@@ -1936,7 +1930,7 @@ private:
 
 #ifdef __VMAWARE_DEBUG__
                 if (result) {
-                    core_debug("HYPER_X: root partition returned true");
+                    core_debug("HYPER_X: running under root partition");
                 }
 #endif
                 return result;
@@ -7832,103 +7826,6 @@ private: // START OF PRIVATE VM DETECTION TECHNIQUE DEFINITIONS
 
 
     /**
-     * @brief Check if any processor has an empty Processor ID using SMBIOS data
-     * @category Windows
-     * @author Requiem (https://github.com/NotRequiem)
-     * @note https://www.dmtf.org/sites/default/files/standards/documents/DSP0134_3.8.0.pdf (Section 7.5.3, page 54)
-     * @implements VM::PROCESSOR_ID
-     */
-    [[nodiscard]] static bool processor_id() {
-#if (!WINDOWS)
-        return false;
-#else
-#pragma pack(push, 1)
-        struct RawSMBIOSData {
-            BYTE  Used20CallingMethod;
-            BYTE  SMBIOSMajorVersion;
-            BYTE  SMBIOSMinorVersion;
-            BYTE  DmiRevision;
-            DWORD Length;
-            BYTE  SMBIOSTableData[1];
-        };
-#pragma pack(pop)
-
-        UINT bufferSize = GetSystemFirmwareTable('RSMB', 0, nullptr, 0);
-        if (bufferSize == 0)
-            return false;
-
-        std::vector<BYTE> buffer(bufferSize);
-        if (GetSystemFirmwareTable('RSMB', 0, buffer.data(), bufferSize) != bufferSize)
-            return false;
-
-        if (buffer.size() < sizeof(RawSMBIOSData))
-            return false;
-
-        RawSMBIOSData* raw = reinterpret_cast<RawSMBIOSData*>(buffer.data());
-        BYTE* tableData = raw->SMBIOSTableData;
-        DWORD tableLength = raw->Length;
-        BYTE* tableEnd = tableData + tableLength;
-        BYTE* p = tableData;
-
-        while (p < tableEnd) {
-            // header: [Type (1B), Length (1B), Handle (2B)]
-            if (p + 4 > tableEnd)
-                break;
-
-            BYTE type = p[0];
-            BYTE length = p[1];
-
-            if (length < 4 || (p + length) > tableEnd)
-                break;
-
-            // Processor Information (Type 4) structures, Processor ID field
-            if (type == 4) {
-                // the Processor ID is an 8‑byte field starting at offset 8 in the structure
-                // Therefore, the structure must be at least 16 bytes long
-                if (length >= 16) {
-                    BYTE* procId = p + 8;
-
-#ifdef __VMAWARE_DEBUG__
-                    std::ostringstream oss;
-                    oss << "PROCESSOR_ID: ";
-                    for (int i = 0; i < 8; ++i) {
-                        oss << std::hex << std::setw(2) << std::setfill('0')
-                            << static_cast<int>(procId[i]) << " ";
-                    }
-                    debug(oss.str());
-#endif
-                    bool allZero = true;
-                    for (int i = 0; i < 8; ++i) {
-                        if (procId[i] != 0) {
-                            allZero = false;
-                            break;
-                        }
-                    }
-                    if (allZero) {
-                        return true;
-                    }
-                }
-            }
-
-            // Skip the formatted section
-            BYTE* next = p + length;
-            // Then skip the unformatted string-set (terminated by double-null)
-            while (next < tableEnd - 1) {
-                if (next[0] == 0 && next[1] == 0) {
-                    next += 2;
-                    break;
-                }
-                ++next;
-            }
-            p = next;
-        }
-
-        return false;
-#endif
-    }
-
-
-    /**
      * @brief Check for timing anomalies in the system
      * @category x86
      * @author Requiem (https://github.com/NotRequiem)
@@ -11339,7 +11236,6 @@ public: // START OF PUBLIC FUNCTIONS
             case PROCESSOR_NUMBER: return "PROCESSOR_NUMBER";
             case NUMBER_OF_CORES: return "NUMBER_OF_CORES";
             case ACPI_TEMPERATURE: return "ACPI_TEMPERATURE";
-            case PROCESSOR_ID: return "PROCESSOR_ID";
             case SYS_QEMU: return "SYS_QEMU";
             case LSHW_QEMU: return "LSHW_QEMU";
             case VIRTUAL_PROCESSORS: return "VIRTUAL_PROCESSORS";
@@ -11901,7 +11797,6 @@ std::pair<VM::enum_flags, VM::core::technique> VM::core::technique_list[] = {
     std::make_pair(VM::PROCESSOR_NUMBER, VM::core::technique(50, VM::processor_number)),
     std::make_pair(VM::NUMBER_OF_CORES, VM::core::technique(50, VM::number_of_cores)),
     std::make_pair(VM::ACPI_TEMPERATURE, VM::core::technique(25, VM::acpi_temperature)),
-    std::make_pair(VM::PROCESSOR_ID, VM::core::technique(25, VM::processor_id)),
     std::make_pair(VM::SYS_QEMU, VM::core::technique(70, VM::sys_qemu_dir)),
     std::make_pair(VM::LSHW_QEMU, VM::core::technique(80, VM::lshw_qemu)),
     std::make_pair(VM::VIRTUAL_PROCESSORS, VM::core::technique(50, VM::virtual_processors)),


### PR DESCRIPTION
The CIM string that we can get from Win32_Processor is not the same value as the one extracted from the SMBIOS table, it comes from CPUID with function 1

The 32‐bit value from EDX -> features and initial signature parts

The 32‐bit value from EAX -> family, model, and stepping 

For example, the CIM string in one of my machines after running wbemtest on root\cimv2 is 'BFEBFBFF000A0655' (EDX = 0xBFEBFBFF and EAX = 0x000A0655)

```cpp
#include <iostream>
#include <intrin.h>
#include <iomanip>
#include <sstream>
#include <string>

std::string GetProcessorId() {
    int cpuInfo[4] = {0};

    __cpuid(cpuInfo, 1);

    // EDX (first) and EAX (second) as 8-hex-digit parts
    std::ostringstream oss;
    oss << std::hex << std::setw(8) << std::setfill('0') << cpuInfo[3] // EDX
        << std::setw(8) << std::setfill('0') << cpuInfo[0];             // EAX
    return oss.str();
}

int main() {
    std::string processorId = GetProcessorId();
    std::cout << "Processor ID: " << processorId << std::endl;
    return 0;
}
```

Modern hypervisors do not return null results for this query. On top of that, this technique completely relies on __cpuid