### PR TITLE
Major changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@
 The library is:
 - Very easy to use
 - Cross-platform (Windows + MacOS + Linux)
-- Features up to 115 unique VM detection techniques [[list](https://github.com/kernelwernel/VMAware/blob/main/docs/documentation.md#flag-table)]
+- Features up to 100+ unique VM detection techniques [[list](https://github.com/kernelwernel/VMAware/blob/main/docs/documentation.md#flag-table)]
 - Features the most cutting-edge techniques
 - Able to detect 65+ VM brands including VMware, VirtualBox, QEMU, Hyper-V, and much more [[list](https://github.com/kernelwernel/VMAware/blob/main/docs/documentation.md#brand-table)]
 - Able to beat VM hardeners
@@ -239,7 +239,7 @@ You can view the full docs [here](docs/documentation.md). All the details such a
 
 > I would've made it strictly MIT so proprietary software can make use of the library, but some of the techniques employed are from GPL projects, and I have no choice but to use the same license for legal reasons. 
 > 
-> This gave me an idea to make an MIT version without all of the GPL code so it can also be used without forcing your code to be open source. It should be noted that the MIT version removes <b>7</b> techniques out of 115 (as of 2.0 version), and the lesser the number of techniques, the less accurate the overall result might be.
+> This gave me an idea to make an MIT version without all of the GPL code so it can also be used without forcing your code to be open source. It should be noted that the MIT version removes <b>7</b> techniques out of 109 (as of 2.0 version), and the lesser the number of techniques, the less accurate the overall result might be.
 
 </details>
 

--- a/docs/documentation.md
+++ b/docs/documentation.md
@@ -440,7 +440,6 @@ VMAware provides a convenient way to not only check for VMs, but also have the f
 | `VM::DMIDECODE` | Check if dmidecode output matches a VM brand | Linux | 55% | Admin |  |  |  |
 | `VM::DMESG` | Check if dmesg output matches a VM brand | Linux | 55% | Admin |  |  |  |
 | `VM::HWMON` | Check if /sys/class/hwmon/ directory is present. If not, likely a VM | Linux | 35% |  |  |  |  |
-| `VM::SIDT5` | Check if the 5th byte after sidt is null | Linux | 45% |  |  |  |  |
 | `VM::DLL` | Check for VM-specific DLLs | Windows | 25% |  |  |  |  |
 | `VM::REGISTRY` |  Check for VM-specific registry values | Windows | 50% |  |  |  |  |
 | `VM::VM_FILES` | Find for VM-specific specific files | Windows | 25% |  |  |  |  |
@@ -466,13 +465,9 @@ VMAware provides a convenient way to not only check for VMs, but also have the f
 | `VM::MAC_SIP` | Check if System Integrity Protection is disabled (likely a VM if it is) | MacOS | 40% |  |  |  |  |
 | `VM::HKLM_REGISTRIES` | Check HKLM registries for specific VM strings | Windows | 25% |  |  |  |  |
 | `VM::VPC_INVALID` | Check for official VPC method | Windows | 75% |  |  | 32-bit |  |
-| `VM::SIDT` | Check for sidt instruction method | Windows | 25% |  |  |  |  |
-| `VM::SGDT` | Check for sgdt instruction method | Windows | 30% |  |  | 32-bit |  |
-| `VM::SLDT` | Check for sldt instruction method | Windows | 15% |  |  | 32-bit |  |
-| `VM::OFFSEC_SIDT` | Check for Offensive Security SIDT method | Windows | 60% |  |  | 32-bit |  |
-| `VM::OFFSEC_SGDT` | Check for Offensive Security SGDT method | Windows | 60% |  |  | 32-bit |  |
-| `VM::OFFSEC_SLDT` | Check for Offensive Security SLDT method | Windows | 20% |  |  | 32-bit |  |
-| `VM::VPC_SIDT` | Check for sidt method with VPC's 0xE8XXXXXX range | Windows | 15% |  |  | 32-bit |  |
+| `VM::SIDT` | Check for uncommon IDT virtual addresses | Linux and Windows | 25% |  |  |  |  |
+| `VM::SGDT` | Check for uncommon GDT virtual addresses | Windows | 30% |  |  |  |  |
+| `VM::SLDT` | Check for uncommon LDT virtual addresses | Windows | 15% |  |  | 32-bit |  |
 | `VM::VMWARE_IOMEM` | Check for VMware string in /proc/iomem | Linux | 65% |  |  |  |  |
 | `VM::VMWARE_IOPORTS` | Check for VMware string in /proc/ioports | Linux | 70% |  |  |  |  |
 | `VM::VMWARE_SCSI` | Check for VMware string in /proc/scsi/scsi | Linux | 40% |  |  |  |  |
@@ -488,8 +483,8 @@ VMAware provides a convenient way to not only check for VMs, but also have the f
 | `VM::NETTITUDE_VM_MEMORY` | Check for memory regions to detect VM-specific brands | Windows | 100% | |  |  |  |
 | `VM::CUCKOO_DIR` | Check for cuckoo directory using crt and WIN API directory functions | Windows | 30% |  |  |  |  |
 | `VM::CUCKOO_PIPE` | Check for Cuckoo specific piping mechanism | Windows | 30% |  |  |  |  |
-| `VM::HYPERV_HOSTNAME` | Check for default Azure hostname format regex (Azure uses Hyper-V as their base VM brand) | Windows, Linux | 30% |  |  |  |  |
-| `VM::GENERAL_HOSTNAME` | Check for commonly set hostnames by certain VM brands | Windows, Linux | 10% |  |  |  |  |
+| `VM::HYPERV_HOSTNAME` | Check for default Azure hostname format regex (Azure uses Hyper-V as their base VM brand) | Linux and Windows | 30% |  |  |  |  |
+| `VM::GENERAL_HOSTNAME` | Check for commonly set hostnames by certain VM brands | Linux and Windows | 10% |  |  |  |  |
 | `VM::SCREEN_RESOLUTION` | Check for pre-set screen resolutions commonly found in VMs | Windows | 20% |  |  |  |  |
 | `VM::DEVICE_STRING` | Check if bogus device string would be accepted | Windows | 25% |  |  |  |  |
 | `VM::BLUESTACKS_FOLDERS` |  Check for the presence of BlueStacks-specific folders | Linux | 5% |  |  |  |  |
@@ -512,7 +507,6 @@ VMAware provides a convenient way to not only check for VMs, but also have the f
 | `VM::ANYRUN_DRIVER` | Check for any.run driver presence | Windows | 65% |  |  |  |  | Removed from the lib, only available in the CLI |
 | `VM::ANYRUN_DIRECTORY` | Check for any.run directory and handle the status code | Windows | 35% |  |  |  |  | Removed from the lib, only available in the CLI |
 | `VM::DRIVER_NAMES` | Check for VM-specific names for drivers | Windows | 100% |  |  |  |  |
-| `VM::VM_SIDT` | Check for unknown IDT base address | Windows | 100% |  |  |  |  |
 | `VM::DISK_SERIAL` | Check for serial numbers of virtual disks | Windows | 100% |  |  |  |  |
 | `VM::PORT_CONNECTORS` | Check for physical connection ports | Windows | 25% |  |  |  | This technique is known to false flag on devices like Surface Pro |
 | `VM::GPU_CAPABILITIES` | Check for GPU capabilities related to VMs | Windows | 100% | Admin |  |  | Admin only needed for some heuristics |
@@ -530,7 +524,7 @@ VMAware provides a convenient way to not only check for VMs, but also have the f
 | `VM::AMD_THREAD_MISMATCH` | Check for AMD CPU thread count database if it matches the system's thread count |  | 95% |  |  |  |  |
 | `VM::NATIVE_VHD` | Check for OS being booted from a VHD container | Windows | 100% |  |  |  |  |
 | `VM::VIRTUAL_REGISTRY` | Check for particular object directory which is present in Sandboxie virtual environment but not in usual host systems | Windows | 65% |  |  |  | Admin only needed for Linux |
-| `VM::FIRMWARE` | Check for VM signatures and patched strings by hardeners in firmware, while ensuring the BIOS serial is valid | Windows and Linux | 100% |  |  |  |  |
+| `VM::FIRMWARE` | Check for VM signatures and patched strings by hardeners in firmware, while ensuring the BIOS serial is valid | Linux and Windows | 100% |  |  |  |  |
 | `VM::FILE_ACCESS_HISTORY` | Check if the number of accessed files are too low for a human-managed environment | Linux | 15% |  |  |  |  |
 | `VM::AUDIO` | Check if any waveform-audio output devices are present in the system | Windows | 25% |  |  |  |  |
 | `VM::UNKNOWN_MANUFACTURER` | Check if the CPU manufacturer is not known |  | 50% |  |  |  |  |

--- a/src/README.md
+++ b/src/README.md
@@ -2,7 +2,7 @@
 |------|---------|
 | `cli.cpp`  | Entire CLI tool code |
 | `vmaware.hpp` | Official and original library header in GPL-3.0, most likely what you're looking for. |
-| `vmaware_MIT.hpp` | Same as above but in MIT. But this removes 7 techniques out of 115 |
+| `vmaware_MIT.hpp` | Same as above but in MIT. But this removes 7 techniques out of 109 |
 
 <br>
 

--- a/src/cli.cpp
+++ b/src/cli.cpp
@@ -350,7 +350,6 @@ bool is_unsupported(VM::enum_flags flag) {
             case VM::DMIDECODE:
             case VM::DMESG:
             case VM::HWMON:
-            case VM::SIDT5:
             case VM::DISK_SIZE:
             case VM::VBOX_DEFAULT:
             case VM::VM_PROCESSES:
@@ -427,10 +426,6 @@ bool is_unsupported(VM::enum_flags flag) {
             case VM::SIDT:
             case VM::SGDT:
             case VM::SLDT:
-            case VM::OFFSEC_SIDT:
-            case VM::OFFSEC_SGDT:
-            case VM::OFFSEC_SLDT:
-            case VM::VPC_SIDT:
             case VM::VMWARE_STR:
             case VM::VMWARE_BACKDOOR:
             case VM::VMWARE_PORT_MEM:
@@ -450,7 +445,6 @@ bool is_unsupported(VM::enum_flags flag) {
             case VM::KVM_BITMASK:
             case VM::KGT_SIGNATURE:
             case VM::DRIVER_NAMES:
-            case VM::VM_SIDT:
             case VM::DISK_SERIAL:
             case VM::PORT_CONNECTORS:
             case VM::GPU_VM_STRINGS:
@@ -874,7 +868,6 @@ void general() {
     checker(VM::HYPERVISOR_BIT, "CPUID hypervisor bit");
     checker(VM::HYPERVISOR_STR, "hypervisor str");
     checker(VM::TIMER, "timing anomalies");
-    checker(VM::SIDT5, "sidt null byte");
     checker(VM::THREADCOUNT, "processor count");
     checker(VM::MAC, "MAC address");
     checker(VM::TEMPERATURE, "temperature");
@@ -912,10 +905,6 @@ void general() {
     checker(VM::SIDT, "SIDT");
     checker(VM::SGDT, "SGDT");
     checker(VM::SLDT, "SLDT");
-    checker(VM::OFFSEC_SIDT, "Offensive Security SIDT");
-    checker(VM::OFFSEC_SGDT, "Offensive Security SGDT");
-    checker(VM::OFFSEC_SLDT, "Offensive Security SLDT");
-    checker(VM::VPC_SIDT, "VirtualPC SIDT");
     checker(VM::VMWARE_IOMEM, "/proc/iomem file");
     checker(VM::VMWARE_IOPORTS, "/proc/ioports file");
     checker(VM::VMWARE_SCSI, "/proc/scsi/scsi file");
@@ -955,7 +944,6 @@ void general() {
     checker(anyrun_driver, "ANY.RUN driver");
     checker(anyrun_directory, "ANY.RUN directory");
     checker(VM::DRIVER_NAMES, "driver names");
-    checker(VM::VM_SIDT, "VM SIDT");
     checker(VM::DISK_SERIAL, "disk serial number");
     checker(VM::PORT_CONNECTORS, "physical connection ports");
     checker(VM::GPU_CAPABILITIES, "GPU capabilities");

--- a/src/vmaware.hpp
+++ b/src/vmaware.hpp
@@ -27,14 +27,14 @@
  *
  *
  * ============================== SECTIONS ==================================
- * - enums for publicly accessible techniques  => line 555
- * - struct for internal cpu operations        => line 739
- * - struct for internal memoization           => line 1210
- * - struct for internal utility functions     => line 1334
- * - struct for internal core components       => line 9950
- * - start of VM detection technique list      => line 2361
- * - start of public VM detection functions    => line 10614
- * - start of externally defined variables     => line 11553
+ * - enums for publicly accessible techniques  => line 551
+ * - struct for internal cpu operations        => line 734
+ * - struct for internal memoization           => line 1206
+ * - struct for internal utility functions     => line 1330
+ * - struct for internal core components       => line 9946
+ * - start of VM detection technique list      => line 2357
+ * - start of public VM detection functions    => line 10610
+ * - start of externally defined variables     => line 11549
  *
  *
  * ============================== EXAMPLE ===================================
@@ -368,8 +368,6 @@
 #include <mmsystem.h>
 #include <dxgi.h>
 #include <d3d9.h>
-#include <d3d11.h>
-#include <d3d12.h>
 
 #pragma comment(lib, "winmm.lib")
 #pragma comment(lib, "setupapi.lib")
@@ -383,10 +381,8 @@
 #pragma comment(lib, "uuid.lib")
 #pragma comment(lib, "ntdll.lib")
 #pragma comment(lib, "powrprof.lib")
-#pragma comment(lib, "d3d9.lib")
-#pragma comment(lib, "d3d11.lib")
-#pragma comment(lib, "d3d12.lib")
 #pragma comment(lib, "dxgi.lib")
+#pragma comment(lib, "d3d9.lib")
 
 #elif (LINUX)
 #if (x86)
@@ -7704,9 +7700,9 @@ private: // START OF PRIVATE VM DETECTION TECHNIQUE DEFINITIONS
 
 #if (WINDOWS)
         constexpr u16 qpcRatioThreshold = 70;           // QPC ratio threshold
+#endif
         constexpr u8 tscIterations = 10;                 // Number of iterations for the TSC synchronization check
         constexpr u16 tscSyncDiffThreshold = 5000;  // TSC difference threshold
-#endif
 
         // to minimize context switching/scheduling
 #if (WINDOWS)

--- a/src/vmaware.hpp
+++ b/src/vmaware.hpp
@@ -27,14 +27,14 @@
  *
  *
  * ============================== SECTIONS ==================================
- * - enums for publicly accessible techniques  => line 551
- * - struct for internal cpu operations        => line 742
- * - struct for internal memoization           => line 1213
- * - struct for internal utility functions     => line 1337
- * - struct for internal core components       => line 10067
- * - start of VM detection technique list      => line 2363
- * - start of public VM detection functions    => line 10731
- * - start of externally defined variables     => line 11677
+ * - enums for publicly accessible techniques  => line 555
+ * - struct for internal cpu operations        => line 739
+ * - struct for internal memoization           => line 1210
+ * - struct for internal utility functions     => line 1334
+ * - struct for internal core components       => line 9950
+ * - start of VM detection technique list      => line 2361
+ * - start of public VM detection functions    => line 10614
+ * - start of externally defined variables     => line 11553
  *
  *
  * ============================== EXAMPLE ===================================
@@ -69,12 +69,12 @@
  *  - the TECHNIQUE table stores all the VM detection technique information in a std::map 
  * 
  *  - the BRAND table stores every VM brand as a std::map as well, but as a scoreboard. 
- *    This mean that if a VM detection has detected a VM brand, that brand will have an
+ *    This means that if a VM detection has detected a VM brand, that brand will have an
  *    incremented score. After every technique is run, the brand with the highest score
  *    is chosen as the officially detected brand. 
  * 
  * The techniques are all static functions, which all return a boolean. There are a few 
- * categories of techniques that target vastly different things such as OS queires, CPU
+ * categories of techniques that target vastly different things such as OS queries, CPU
  * values, other hardware values, firmware data, and system files just to name a few. 
  * 
  * 
@@ -97,7 +97,7 @@
  *        confused with "memorization"). More specifically, this allows us to cache 
  *        a technique result in a table where each entry contains a technique and its
  *        result. This allows us to avoid re-running techniques which happens a lot
- *        internally. Some techniques are more costlier than others in terms of 
+ *        internally. Some techniques are costlier than others in terms of 
  *        performance, so this is a crucial module that allows us to save a lot of
  *        time. Additionally, it contains other memoization caches for various other
  *        things for convenience purposes. 
@@ -116,7 +116,7 @@
  *    1. The function tries to handle the user arguments (if there's 
  *       any), and generates a std::bitset. This bitset has a length of 
  *       every VM detection technique + settings, where each bit 
- *       corresponds to whether this technique will be ran or not, 
+ *       corresponds to whether this technique will be run or not, 
  *       and which settings were selected. 
  * 
  *    2. After the bitset has been generated, this information is then 
@@ -132,7 +132,7 @@
  *       If it hasn't, run the technique and cache the result to the 
  *       cache table. 
  * 
- *    4. After every technique has been looped through, this generates a 
+ *    4. After every technique has been executed, this generates a 
  *       uint16_t score. Every technique has a score value between 0 to 
  *       100, and if they are detected then this score is accumulated to 
  *       a total score. If the total is above 150, that means it's a VM[1]. 
@@ -147,7 +147,7 @@
  *       important is because a lot of techniques increment a point for its 
  *       respected brand that was detected. For example, if the VM::QEMU_USB
  *       technique has detected a VM, it'll add a score to the QEMU brand in
- *       the scoreboard. If no technique has been ran, then there's no way to
+ *       the scoreboard. If no technique has been run, then there's no way to
  *       populate the scoreboard with any points. After every VM detection 
  *       technique has been invoked/retrieved, the brand scoreboard is now
  *       ready to be analysed.
@@ -170,8 +170,8 @@
  *       output of the VM::brand() function.
  * 
  *    6. The result is then cached to the memo module, so if another function
- *       invokes VM:brand() again, the result is retrieved from the cache
- *       without having it run all of the previous steps mentioned.
+ *       invokes VM:brand() again, "the result is retrieved from the cache 
+ *       without needing to run all of the previous steps again.
  *      
  * (NOTE: it's a bit more complicated than this, but that's the gist of how this function works)
  * 
@@ -179,7 +179,7 @@
  * And they serve as a functionality base for other components of the lib.
  *      
  *  
- *  [1]: If the user has inputted a setting argument called VM::HIGH_THRESHOLD, 
+ *  [1]: If the user has provided a setting argument called VM::HIGH_THRESHOLD, 
  *       the threshold becomes 300 instead of 150.
  */
 
@@ -368,9 +368,9 @@
 #include <mmsystem.h>
 #include <dxgi.h>
 #include <d3d9.h>
+#include <d3d11.h>
+#include <d3d12.h>
 
-#pragma comment(lib, "dxgi.lib")
-#pragma comment(lib, "d3d9.lib")
 #pragma comment(lib, "winmm.lib")
 #pragma comment(lib, "setupapi.lib")
 #pragma comment(lib, "iphlpapi.lib")
@@ -383,6 +383,10 @@
 #pragma comment(lib, "uuid.lib")
 #pragma comment(lib, "ntdll.lib")
 #pragma comment(lib, "powrprof.lib")
+#pragma comment(lib, "d3d9.lib")
+#pragma comment(lib, "d3d11.lib")
+#pragma comment(lib, "d3d12.lib")
+#pragma comment(lib, "dxgi.lib")
 
 #elif (LINUX)
 #if (x86)
@@ -564,7 +568,6 @@ public:
         DMIDECODE,
         DMESG,
         HWMON,
-        SIDT5,
         DLL,
         REGISTRY,
         VM_FILES,
@@ -593,10 +596,6 @@ public:
         SIDT,
         SGDT,
         SLDT,
-        OFFSEC_SIDT,
-        OFFSEC_SGDT,
-        OFFSEC_SLDT,
-        VPC_SIDT,
         VMWARE_IOMEM,
         VMWARE_IOPORTS,
         VMWARE_SCSI,
@@ -634,7 +633,6 @@ public:
         PODMAN_FILE,
         WSL_PROC,
         DRIVER_NAMES,
-        VM_SIDT,
         DISK_SERIAL,
         PORT_CONNECTORS,
         GPU_VM_STRINGS,
@@ -1991,6 +1989,7 @@ private:
                 }
             }
             else {
+                // normally eax 12
                 const std::string brand_str = cpu::cpu_manufacturer(0x40000001);
 
                 if (util::find(brand_str, "KVM")) {
@@ -2825,13 +2824,15 @@ private: // START OF PRIVATE VM DETECTION TECHNIQUE DEFINITIONS
 
 
     /**
-     * @brief Check if the 5th byte after sidt is null
-     * @author Matteo Malvica
-     * @link https://www.matteomalvica.com/blog/2018/12/05/detecting-vmware-on-64-bit-systems/
-     * @category Linux
-     * @implements VM::SIDT5
+     * @brief Check for uncommon IDT virtual addresses
+     * @author Matteo Malvica (Linux)
+     * @link https://www.matteomalvica.com/blog/2018/12/05/detecting-vmware-on-64-bit-systems/ (Linux)
+     * @note Idea to check VPC's range from Tom Liston and Ed Skoudis' paper "On the Cutting Edge: Thwarting Virtual Machine Detection" (Windows)
+     * @note Paper situated at /papers/ThwartingVMDetection_Liston_Skoudis.pdf (Windows)
+     * @category Windows, Linux
+     * @implements VM::SIDT
      */
-    [[nodiscard]] static bool sidt5() {
+    [[nodiscard]] static bool sidt() {
 #if (LINUX && (GCC || CLANG))
         u8 values[10] = { 0 };
 
@@ -2869,8 +2870,41 @@ private: // START OF PRIVATE VM DETECTION TECHNIQUE DEFINITIONS
         return false;
 #endif
 
+#elif (WINDOWS)
+        unsigned char m[6] = { 0 };
+        u32	idt = 0;
+
+        __try {
+#if (CLANG || GCC)
+            __asm__ volatile ("sidt %0" : "=m"(m));
+#elif (MSVC && x86_32)
+            __asm {
+                sidt m
+            }
+#elif (MSVC)
+#pragma pack(push, 1)
+            struct {
+                unsigned short limit;
+                unsigned long long base;
+            } idtr = {};
+#pragma pack(pop)
+
+            __sidt(&idtr);
+            std::memcpy(m, &idtr, sizeof(m));
 #else
-        return false;
+            return false;
+#endif
+        }
+        __except (EXCEPTION_EXECUTE_HANDLER) {
+            return false; // umip
+        }
+        idt = *((unsigned long*)&m[2]);
+
+        if ((idt >> 24) == 0xE8) {
+            return core::add(brands::VPC);
+        }
+
+        return (m[5] > 0xD0); // top‐most byte of the 64‑bit base
 #endif
     }
 
@@ -4341,13 +4375,11 @@ private: // START OF PRIVATE VM DETECTION TECHNIQUE DEFINITIONS
 
     /**
      * @brief Check for official VPC method
-     * @category Windows, x86
+     * @category Windows, x86_32
      * @implements VM::VPC_INVALID
      */
     [[nodiscard]] static bool vpc_invalid() {
-#if (!WINDOWS || !x86_64)
-        return false;
-#elif (x86_32)
+#if (WINDOWS && x86_32)
         bool rc = false;
 
         auto IsInsideVPC_exceptionFilter = [](PEXCEPTION_POINTERS ep) -> DWORD {
@@ -4395,79 +4427,46 @@ private: // START OF PRIVATE VM DETECTION TECHNIQUE DEFINITIONS
 
 
     /**
-     * @brief Check for sidt instruction method
-     * @category Linux, Windows, x86
-     * @implements VM::SIDT
-     */
-    [[nodiscard]] static bool sidt() {
-#if (!WINDOWS)
-        return false;
-#else
-        u8 idtr[10]{};
-        u32 idt_entry = 0;
-
-#   if (x86_32)
-        __try {
-#           if (CLANG || GCC)
-                __asm__ volatile("sidt %0" : "=m"(idtr));
-#           else
-                _asm sidt idtr
-#           endif
-        }
-        __except (EXCEPTION_EXECUTE_HANDLER) {
-            return false;  // UMIP
-        }
-#   elif (x86_64)
-#       pragma pack(push, 1)
-        struct IDTR {
-            u16 limit;
-            u64 base;
-        };
-#       pragma pack(pop)
-
-        IDTR idtrStruct = {};
-        __try {
-#           if (CLANG || GCC)
-                __asm__ volatile("sidt %0" : "=m"(idtrStruct));
-#           else
-                __sidt(&idtrStruct);
-#           endif
-        }
-        __except (EXCEPTION_EXECUTE_HANDLER) {
-            return false;
-        }
-        std::memcpy(idtr, &idtrStruct, sizeof(idtr));
-#   else
-        return false;
-#   endif
-
-        idt_entry = *reinterpret_cast<unsigned long*>(&idtr[2]);
-        return ((idt_entry >> 24) == 0xFF) ? core::add(brands::VMWARE) : false;
-#endif
-    }
-
-
-    /**
      * @brief Check for sgdt instruction method
-     * @category Windows, x86
+     * @category Windows
+     * @author Danny Quist (chamuco@gmail.com) (top-most byte signature)
+     * @author Val Smith (mvalsmith@metasploit.com) (top-most byte signature)
+     * @note code documentation paper in /papers/www.offensivecomputing.net_vm.pdf (top-most byte signature)
      * @implements VM::SGDT
      */
     [[nodiscard]] static bool sgdt() {
-#if defined(_M_IX86) && defined(_WIN32)
-        
-            unsigned char gdtr[6] = { 0 };
-            unsigned int gdt = 0;
+#if (WINDOWS)
+        unsigned char gdtr[6] = { 0 };
+        unsigned int  gdt = 0;
+
         __try {
+#if (CLANG || GCC)
+            __asm__ volatile("sgdt %0" : "=m"(gdtr));
+#elif (MSVC && x86_32)
             __asm {
                 sgdt gdtr
             }
-            gdt = *reinterpret_cast<unsigned int*>(&gdtr[2]);
-            return ((gdt >> 24) == 0xFF);
+#elif (MSVC)
+    #pragma pack(push, 1)
+            struct { unsigned short limit; unsigned long long base; } _gdtr = {};
+    #pragma pack(pop)
+            _sgdt(&_gdtr);
+            std::memcpy(gdtr, &_gdtr, sizeof(gdtr));
+#else
+            return false;
+#endif
         }
         __except (EXCEPTION_EXECUTE_HANDLER) {
-            // umip
-            return false;
+            return false; // umip
         }
+
+        std::memcpy(&gdt, &gdtr[2], sizeof(gdt));
+
+        if (gdtr[5] > 0xD0) { // top‐most byte of the 64‑bit base
+            debug("SGDT: top-most byte signature detected");
+            return true;
+        }
+        return ((gdt >> 24) == 0xFF);
 #else
         return false;
 #endif
@@ -4476,137 +4475,39 @@ private: // START OF PRIVATE VM DETECTION TECHNIQUE DEFINITIONS
 
     /**
      * @brief Check for sldt instruction method
-     * @category Windows, x86
-     * @note code documentation paper in https://www.aldeid.com/wiki/X86-assembly/Instructions/sldt
+     * @category Windows, x86_32
+     * @author Danny Quist (chamuco@gmail.com), ldtr_buf signature
+     * @author Val Smith (mvalsmith@metasploit.com), ldtr_buf signature
+     * @note code documentation paper in /papers/www.offensivecomputing.net_vm.pdf for ldtr_buf signature
+     * @note code documentation paper in https://www.aldeid.com/wiki/X86-assembly/Instructions/sldt for ldt signature
      * @implements VM::SLDT
      */
     [[nodiscard]] static bool sldt() {
-#if (!MSVC && WINDOWS)
-        unsigned char ldtr[5] = "\xef\xbe\xad\xde";
+#if (WINDOWS && x86_32)
+        unsigned char ldtr_buf[4] = { 0xEF, 0xBE, 0xAD, 0xDE };
         unsigned long ldt = 0;
+
         __try {
+#if (CLANG || GCC)
+            __asm__ volatile("sldt %0" : "=m"(*(unsigned short*)ldtr_buf));
+#elif (MSVC)
             __asm {
-                sldt word ptr ldtr  // 'word ptr' to indicate that we're working with a 16-bit value and avoid compiler warnings
+                sldt ax
+                mov  word ptr[ldtr_buf], ax
             }
-        }
-        __except (EXCEPTION_EXECUTE_HANDLER) {
-            // umip
-            return false;
-        }
-
-        ldt = *((unsigned long*)&ldtr[0]);
-
-        return (ldt != 0xdead0000);
-#else
-        return false;
 #endif
-    }
-
-
-    /**
-     * @brief Check for Offensive Security sidt method
-     * @category Windows, x86
-     * @author Danny Quist (chamuco@gmail.com)
-     * @author Val Smith (mvalsmith@metasploit.com)
-     * @note code documentation paper in /papers/www.offensivecomputing.net_vm.pdf
-     * @implements VM::OFFSEC_SIDT
-     */
-    [[nodiscard]] static bool offsec_sidt() {
-#if (!MSVC && WINDOWS)
-        unsigned char m[6]{};
-        __try {
-            __asm sidt m;
         }
         __except (EXCEPTION_EXECUTE_HANDLER) {
             return false; // umip
         }
 
-        return (m[5] > 0xD0);
-#else
-        return false;
-#endif
-    }
-
-
-    /**
-     * @brief Check for Offensive Security sgdt method
-     * @category Windows, x86
-     * @author Danny Quist (chamuco@gmail.com)
-     * @author Val Smith (mvalsmith@metasploit.com)
-     * @note code documentation paper in /papers/www.offensivecomputing.net_vm.pdf
-     * @implements VM::OFFSEC_SGDT
-     */
-    [[nodiscard]] static bool offsec_sgdt() {
-#if (!MSVC && WINDOWS)
-        unsigned char m[6]{};
-        __try {
-            __asm sgdt m;
-        }
-        __except (EXCEPTION_EXECUTE_HANDLER) {
-            // umip
-            return false;
+        std::memcpy(&ldt, ldtr_buf, sizeof(ldt));
+        if (ldtr_buf[0] != 0x00 && ldtr_buf[1] != 0x00) {
+            debug("SLDT: ldtr_buf signature detected");
+            return true;
         }
 
-        return (m[5] > 0xD0);
-#else
-        return false;
-#endif
-    }
-
-
-    /**
-     * @brief Check for Offensive Security sldt method
-     * @category Windows, x86
-     * @author Danny Quist (chamuco@gmail.com)
-     * @author Val Smith (mvalsmith@metasploit.com)
-     * @note code documentation paper in /papers/www.offensivecomputing.net_vm.pdf
-     * @implements VM::OFFSEC_SLDT
-     */
-    [[nodiscard]] static bool offsec_sldt() {
-#if (!WINDOWS || !x86_64)
-        return false;
-#elif (x86_32)
-        unsigned short m[6]{};
-        __try {
-            __asm sldt m;
-        }
-        __except (EXCEPTION_EXECUTE_HANDLER) {
-            // umip
-            return false;
-        }
-        return (m[0] != 0x00 && m[1] != 0x00);
-#else
-        return false;
-#endif
-    }
-
-
-    /**
-     * @brief Check for sidt method with VPC's 0xE8XXXXXX range
-     * @category Windows, x86
-     * @note Idea from Tom Liston and Ed Skoudis' paper "On the Cutting Edge: Thwarting Virtual Machine Detection"
-     * @note Paper situated at /papers/ThwartingVMDetection_Liston_Skoudis.pdf
-     * @implements VM::VPC_SIDT
-     */
-    [[nodiscard]] static bool vpc_sidt() {
-#if (!WINDOWS || !x86_64)
-        return false;
-#elif (x86_32)
-        u8	idtr[6]{};
-        u32	idt = 0;
-        __try {
-            _asm sidt idtr
-        }
-        __except (EXCEPTION_EXECUTE_HANDLER) {
-            return false; // umip
-        }
-        idt = *((unsigned long*)&idtr[2]);
-
-        if ((idt >> 24) == 0xE8) {
-            return core::add(brands::VPC);
-        }
-
-        return false;
+        return (ldt != 0xDEAD0000);
 #else
         return false;
 #endif
@@ -4738,7 +4639,7 @@ private: // START OF PRIVATE VM DETECTION TECHNIQUE DEFINITIONS
 
     /**
      * @brief Check for official VMware io port backdoor technique
-     * @category Windows, x86
+     * @category Windows, x86_32
      * @note Code from ScoopyNG by Tobias Klein
      * @note Technique founded by Ken Kato
      * @copyright BSD clause 2
@@ -4803,7 +4704,7 @@ private: // START OF PRIVATE VM DETECTION TECHNIQUE DEFINITIONS
 
     /**
      * @brief Check for VMware memory using IO port backdoor
-     * @category Windows, x86
+     * @category Windows, x86_32
      * @note Code from ScoopyNG by Tobias Klein
      * @copyright BSD clause 2
      * @implements VM::VMWARE_PORT_MEM
@@ -4848,7 +4749,7 @@ private: // START OF PRIVATE VM DETECTION TECHNIQUE DEFINITIONS
 
     /**
      * @brief Check for SMSW assembly instruction technique
-     * @category Windows, x86
+     * @category Windows, x86_32
      * @author Danny Quist from Offensive Computing
      * @implements VM::SMSW
      */
@@ -4877,7 +4778,7 @@ private: // START OF PRIVATE VM DETECTION TECHNIQUE DEFINITIONS
 
     /**
      * @brief Check for mutex strings of VM brands
-     * @category Windows, x86
+     * @category Windows
      * @note from VMDE project
      * @author hfiref0x
      * @implements VM::MUTEX
@@ -4924,7 +4825,7 @@ private: // START OF PRIVATE VM DETECTION TECHNIQUE DEFINITIONS
 
     /**
      * @brief Check for odd CPU threads, usually a sign of modification through VM setting because 99% of CPUs have even numbers of threads
-     * @category All, x86
+     * @category x86
      * @implements VM::ODD_CPU_THREADS
      */
     [[nodiscard]] static bool odd_cpu_threads() {
@@ -5024,7 +4925,7 @@ private: // START OF PRIVATE VM DETECTION TECHNIQUE DEFINITIONS
 
     /**
      * @brief Check for Intel CPU thread count database if it matches the system's thread count
-     * @category All, x86
+     * @category x86
      * @implements VM::INTEL_THREAD_MISMATCH
      */
     [[nodiscard]] static bool intel_thread_mismatch() {
@@ -6025,7 +5926,7 @@ private: // START OF PRIVATE VM DETECTION TECHNIQUE DEFINITIONS
 
     /**
      * @brief Same as above, but for Xeon Intel CPUs
-     * @category All, x86
+     * @category x86
      * @link https://en.wikipedia.org/wiki/List_of_Intel_Core_processors
      * @implements VM::XEON_THREAD_MISMATCH
      */
@@ -6175,7 +6076,7 @@ private: // START OF PRIVATE VM DETECTION TECHNIQUE DEFINITIONS
 
         debug("XEON_THREAD_MISMATCH: thread in database = ", static_cast<u32>(threads));
 
-        return (std::thread::hardware_concurrency() != (threads < 0 ? 0 : static_cast<unsigned int>(threads)));
+        return (std::thread::hardware_concurrency() != static_cast<unsigned int>(threads));
 #endif
     }
 
@@ -7346,41 +7247,6 @@ private: // START OF PRIVATE VM DETECTION TECHNIQUE DEFINITIONS
 
 
     /**
-     * @brief Check for unknown IDT base address
-     * @category Windows
-     * @implements VM::VM_SIDT
-     */
-    [[nodiscard]] static bool vm_sidt() {
-#if (!WINDOWS || !x86) 
-        return false;
-#else    
-#pragma pack(push, 1)
-        struct IDTR { uint16_t limit;  uint64_t base; };
-#pragma pack(pop)
-
-        IDTR idtr;
-        __try {
-            #if (CLANG || GCC)
-                __asm__ volatile("sidt %0" : "=m"(idtr));
-            #else
-                 __sidt(&idtr);
-            #endif
-        }
-        __except (EXCEPTION_EXECUTE_HANDLER) {
-            return false; // umip
-        }
-        u64 idt_base = idtr.base;
-
-        if ((idt_base >> 24) == 0xff) {
-            return true;
-        }
-
-        return false;
-#endif
-    }
-
-
-    /**
      * @brief Check for serial numbers of virtual disks
      * @category Windows
      * @author Requiem (https://github.com/NotRequiem)
@@ -7541,50 +7407,59 @@ private: // START OF PRIVATE VM DETECTION TECHNIQUE DEFINITIONS
 #if (!WINDOWS)
         return false;
 #else
+
+#if (CPP >= 17)
         struct VMGpuInfo {
-            const wchar_t* name;  
+            std::wstring_view name;
             const char* brand;
-            size_t length;       
         };
 
-        constexpr std::array<VMGpuInfo, 10> vm_gpu_names = { {
-            { L"VMware SVGA 3D",                   brands::VMWARE,   14 },
-            { L"VirtualBox Graphics Adapter",      brands::VBOX,     27 },
-            { L"QXL GPU",                          brands::KVM,      7 },
-            { L"VirGL 3D",                         brands::QEMU,     8 },
-            { L"Microsoft Hyper-V Video",          brands::HYPERV,   23 },
-            { L"Parallels Display Adapter (WDDM)", brands::PARALLELS, 32 },
-            { L"Bochs Graphics Adapter",           brands::BOCHS,    22 },
-            { L"Bochs Graphics Adapter",           brands::BOCHS,    22 },
-            { L"Virtual Display Driver",           brands::NULL_BRAND,  22 },
-            { L"IddSampleDriver Device",           brands::NULL_BRAND,  22 }
+        static constexpr std::array<VMGpuInfo, 8> vm_gpu_names = { {
+            { L"VMware SVGA 3D",                   brands::VMWARE    },
+            { L"VirtualBox Graphics Adapter",      brands::VBOX      },
+            { L"QXL GPU",                          brands::KVM       },
+            { L"VirGL 3D",                         brands::QEMU      },
+            { L"Microsoft Hyper-V Video",          brands::HYPERV    },
+            { L"Parallels Display Adapter (WDDM)", brands::PARALLELS },
+            { L"Bochs Graphics Adapter",           brands::BOCHS     },
+            { L"IddSampleDriver Device",           brands::NULL_BRAND}
         } };
+#else
+        struct VMGpuInfo {
+            const wchar_t* name;
+            const char* brand;
+        };
+
+        static const VMGpuInfo vm_gpu_names[8] = {
+            { L"VMware SVGA 3D",                   brands::VMWARE    },
+            { L"VirtualBox Graphics Adapter",      brands::VBOX      },
+            { L"QXL GPU",                          brands::KVM       },
+            { L"VirGL 3D",                         brands::QEMU      },
+            { L"Microsoft Hyper-V Video",          brands::HYPERV    },
+            { L"Parallels Display Adapter (WDDM)", brands::PARALLELS },
+            { L"Bochs Graphics Adapter",           brands::BOCHS     },
+            { L"IddSampleDriver Device",           brands::NULL_BRAND}
+        };
+#endif
 
         DISPLAY_DEVICEW dd{};
-        dd.cb = sizeof(DISPLAY_DEVICEW);
-        DWORD deviceNum = 0;
+        dd.cb = sizeof(dd);
 
-        while (EnumDisplayDevicesW(nullptr, deviceNum, &dd, 0)) {
-            const wchar_t* deviceStr = dd.DeviceString;
-            const size_t deviceStrLen = wcslen(deviceStr);
-
-#if CPP >= 17
-            for (const auto& [name, brand, len] : vm_gpu_names) {
-#else
-            for (const auto& entry : vm_gpu_names) {
-                const wchar_t* name = entry.name;
-                const char* brand = entry.brand;
-                const size_t len = entry.length;
-#endif
-                if (deviceStrLen == len && wcscmp(deviceStr, name) == 0) {   
-                    char* castedName = (char*)calloc(len, sizeof(char));
-                    size_t ret = wcstombs(castedName, name, len);
-                    castedName[ret] = '\0';
-                    return core::add(brand);
+        for (DWORD deviceNum = 0; EnumDisplayDevicesW(nullptr, deviceNum, &dd, 0); ++deviceNum) {
+#if (CPP >= 17)
+            std::wstring_view devStr{ dd.DeviceString };
+            for (auto const& info : vm_gpu_names) {
+                if (devStr == info.name) {
+                    return core::add(info.brand);
                 }
             }
-
-            ++deviceNum;
+#else
+            for (int i = 0; i < 8; ++i) {
+                if (wcscmp(dd.DeviceString, vm_gpu_names[i].name) == 0) {
+                    return core::add(vm_gpu_names[i].brand);
+                }
+            }
+#endif
         }
 
         return false;
@@ -7602,10 +7477,6 @@ private: // START OF PRIVATE VM DETECTION TECHNIQUE DEFINITIONS
 #if (!WINDOWS)
         return false;
 #else
-        if (!util::is_admin()) {
-            return false;
-        }
-
         IDirect3D9* pD3D = Direct3DCreate9(D3D_SDK_VERSION);
         if (!pD3D) {
             debug("GPU_CAPABILITIES: Direct3DCreate9 failed");
@@ -7614,48 +7485,14 @@ private: // START OF PRIVATE VM DETECTION TECHNIQUE DEFINITIONS
 
         D3DADAPTER_IDENTIFIER9 adapterId;
         if (SUCCEEDED(pD3D->GetAdapterIdentifier(D3DADAPTER_DEFAULT, 0, &adapterId))) {
-            if (adapterId.VendorId == 0x15AD) {   
+            if (adapterId.VendorId == 0x15AD) {
                 pD3D->Release();
                 return core::add(brands::VMWARE);
             }
-            else if (adapterId.VendorId == 0x80EE) {   
+            else if (adapterId.VendorId == 0x80EE) {
                 pD3D->Release();
                 return core::add(brands::VBOX);
             }
-        }
-
-        D3DCAPS9 caps;
-        HRESULT hr = pD3D->GetDeviceCaps(D3DADAPTER_DEFAULT, D3DDEVTYPE_HAL, &caps);
-        const int maxRetries = 3;
-        for (int attempt = 0; FAILED(hr) && (attempt < maxRetries); ++attempt) {
-            SleepEx(500, FALSE);  
-            hr = pD3D->GetDeviceCaps(D3DADAPTER_DEFAULT, D3DDEVTYPE_HAL, &caps);
-        }
-        if (FAILED(hr)) {
-            debug("GPU_CAPABILITIES: GetDeviceCaps failure");
-            pD3D->Release();
-            return false;
-        }
-
-        // Pixel Shader version 2.0
-        if (caps.PixelShaderVersion < D3DPS_VERSION(2, 0)) {
-            debug("GPU_CAPABILITIES: Insufficient Pixel Shader version");
-            pD3D->Release();
-            return true;
-        }
-
-        // hardware transform and lighting capability
-        if (!(caps.DevCaps & D3DDEVCAPS_HWTRANSFORMANDLIGHT)) {
-            debug("GPU_CAPABILITIES: Missing hardware T&L support");
-            pD3D->Release();
-            return true;
-        }
-
-        // simultaneous render targets
-        if (caps.NumSimultaneousRTs < 2) {
-            debug("GPU_CAPABILITIES: Insufficient simultaneous render targets");
-            pD3D->Release();
-            return true;
         }
 
         pD3D->Release();
@@ -7666,12 +7503,14 @@ private: // START OF PRIVATE VM DETECTION TECHNIQUE DEFINITIONS
             return true;
         }
 
-        IDXGIAdapter* pAdapter = nullptr;
         // Enumerate only the primary adapter so as not to mistakenly flag machines without a dedicated GPU, like Microsoft Basic Render Driver (vid 0x1414)
-        if (pFactory->EnumAdapters(0, &pAdapter) != DXGI_ERROR_NOT_FOUND) {
+        IDXGIAdapter* pAdapter = nullptr;
+        HRESULT hrEnum = pFactory->EnumAdapters(0, &pAdapter);
+        if (SUCCEEDED(hrEnum)) {
             DXGI_ADAPTER_DESC adapterDesc;
             if (SUCCEEDED(pAdapter->GetDesc(&adapterDesc))) {
-                if (adapterDesc.DedicatedVideoMemory < (1024ULL * 1024ULL * 1024ULL)) {
+                const UINT64 minVidMem = 1024ULL * 1024ULL * 1024ULL;
+                if (adapterDesc.DedicatedVideoMemory < minVidMem) {
                     debug("GPU_CAPABILITIES: Video memory below threshold");
                     pAdapter->Release();
                     pFactory->Release();
@@ -7680,11 +7519,12 @@ private: // START OF PRIVATE VM DETECTION TECHNIQUE DEFINITIONS
             }
             pAdapter->Release();
         }
-        pFactory->Release();
 
+        pFactory->Release();
         return false;
 #endif
     }
+
 
 
     /**
@@ -7821,7 +7661,7 @@ private: // START OF PRIVATE VM DETECTION TECHNIQUE DEFINITIONS
         SP_DEVICE_INTERFACE_DATA deviceInterfaceData{};
         deviceInterfaceData.cbSize = sizeof(SP_DEVICE_INTERFACE_DATA);
 
-        bool exists = SetupDiEnumDeviceInterfaces(hDevInfo, nullptr, &GUID_DEVCLASS_THERMALZONE, 0, &deviceInterfaceData);
+        const bool exists = SetupDiEnumDeviceInterfaces(hDevInfo, nullptr, &GUID_DEVCLASS_THERMALZONE, 0, &deviceInterfaceData);
         SetupDiDestroyDeviceInfoList(hDevInfo);
 
         return !exists;
@@ -7835,11 +7675,11 @@ private: // START OF PRIVATE VM DETECTION TECHNIQUE DEFINITIONS
      * @author Requiem (https://github.com/NotRequiem)
      * @implements VM::TIMER
      */
-#if defined(MSVC)
+#if (MSVC)
     #pragma optimize("", off)
-#elif defined(CLANG)
+#elif (CLANG)
     #pragma clang optimize off
-#elif defined(GCC)
+#elif (GCC)
     #pragma GCC push_options
     #pragma GCC optimize("O0")
 #endif
@@ -7860,7 +7700,7 @@ private: // START OF PRIVATE VM DETECTION TECHNIQUE DEFINITIONS
         constexpr u8 requiredClassicSpikes = rdtscIterations / 2; // At least 50% of iterations must spike
 
         constexpr u16 spammerIterations = 1000;           // Iterations for the multi-CPU/spammer check
-        constexpr u16 spammerAvgThreshold = 1500;         // Average cycle threshold for the spammer check
+        constexpr u16 spammerAvgThreshold = 5000;         // Average cycle threshold for the spammer check
 
 #if (WINDOWS)
         constexpr u16 qpcRatioThreshold = 70;           // QPC ratio threshold
@@ -7961,7 +7801,7 @@ private: // START OF PRIVATE VM DETECTION TECHNIQUE DEFINITIONS
             if (flushBuffer) {
                 for (size_t j = offsetStart; j < offsetEnd; j += 64) {
                     flushBuffer[j] = static_cast<char>(j);
-#if defined(x86) && (defined(GCC) || defined(CLANG) || defined(MSVC))
+#if (x86) && (GCC || CLANG || MSVC)
                     COMPILER_BARRIER();
                     // _mm_clflushopt not available on some systems
                     _mm_clflush(reinterpret_cast<const void*>(&flushBuffer[j]));
@@ -7994,31 +7834,56 @@ private: // START OF PRIVATE VM DETECTION TECHNIQUE DEFINITIONS
         // --- 2. Multi-CPU Spammer Check ---
         // rdtsc+cpuid+rdtsc on CPU1 while CPU2 spams cpuid. This detection tries to detect invariant TSC to flag hypervisors that share the same timer across multiple vCPUs
         std::atomic<bool> stopSpammer{ false };
-        std::thread spammer([&stopSpammer] {
+        bool spammerThreadStarted = false;
+        bool singleCore = false;
+
+        std::thread spammer;
+
+        try {
+            spammer = std::thread([&stopSpammer, &singleCore] {
+                try {
 #if (WINDOWS)
-            SetThreadAffinityMask(GetCurrentThread(), 2);
+                    if (!SetThreadAffinityMask(GetCurrentThread(), 2)) {
+                        singleCore = true;
+                        return;
+                    }
 #elif (LINUX)
-            cpu_set_t cpuset;
-            CPU_ZERO(&cpuset);
-            CPU_SET(1, &cpuset);  // core 1 (0-indexed)
-            pthread_setaffinity_np(pthread_self(), sizeof(cpu_set_t), &cpuset);
+                    cpu_set_t cpuset;
+                    CPU_ZERO(&cpuset);
+                    CPU_SET(1, &cpuset); // core 1 (0-indexed)
+                    if (pthread_setaffinity_np(pthread_self(), sizeof(cpu_set_t), &cpuset) != 0) {
+                        singleCore = true;
+                        return;
+                    }
 #elif (APPLE)
-            thread_affinity_policy_data_t policy = { 1 };
-            thread_policy_set(pthread_mach_thread_np(pthread_self()),
-                THREAD_AFFINITY_POLICY,
-                (thread_policy_t)&policy, 1);
+                    thread_affinity_policy_data_t policy = { 1 };
+                    if (thread_policy_set(pthread_mach_thread_np(pthread_self()),
+                        THREAD_AFFINITY_POLICY,
+                        (thread_policy_t)&policy, 1) != KERN_SUCCESS) {
+                        singleCore = true;
+                        return;
+                    }
 #endif
-            // hypervisor trap pressure
-            while (!stopSpammer.load()) {
+                    // hypervisor trap pressure
+                    while (!stopSpammer.load()) {
 #if (WINDOWS)
-                int cpu_info[4];
-                __cpuid(cpu_info, 0);
+                        int cpu_info[4];
+                        __cpuid(cpu_info, 0); // no need for memory barrier as cpuid is a full memory barrier on itself
 #elif (LINUX || APPLE)
-                u32 eax = 0, ebx = 0, ecx = 0, edx = 0;
-                __cpuid(0, eax, ebx, ecx, edx);
+                        u32 eax = 0, ebx = 0, ecx = 0, edx = 0;
+                        __cpuid(0, eax, ebx, ecx, edx);
 #endif
-            }
-            });
+                    }
+                }
+                catch (...) {
+                    singleCore = true;
+                }
+                });
+            spammerThreadStarted = true;
+        }
+        catch (...) {
+           
+        }
 
         // --- 3a. Pin Measurement Thread for Consistent Timing ---
 #if (WINDOWS)
@@ -8033,7 +7898,6 @@ private: // START OF PRIVATE VM DETECTION TECHNIQUE DEFINITIONS
         CPU_SET(0, &newCpuSet);  // core 0 for consistent timing
         pthread_setaffinity_np(pthread_self(), sizeof(cpu_set_t), &newCpuSet);
 #elif (APPLE)
-        // restoration is not supported on Apple
         thread_affinity_policy_data_t policy = { 1 };
         thread_policy_set(pthread_mach_thread_np(pthread_self()),
             THREAD_AFFINITY_POLICY,
@@ -8054,9 +7918,13 @@ private: // START OF PRIVATE VM DETECTION TECHNIQUE DEFINITIONS
             u64 end = __rdtsc();
             measurement += (end - start);
         }
-        stopSpammer.store(true);
-        spammer.join();
 
+        stopSpammer.store(true);
+        if (spammerThreadStarted) {
+            spammer.join();
+        }
+
+        // Restore affinity
 #if (WINDOWS)
         SetThreadAffinityMask(GetCurrentThread(), oldAffinityMask);
 #elif (LINUX)
@@ -8068,14 +7936,13 @@ private: // START OF PRIVATE VM DETECTION TECHNIQUE DEFINITIONS
         debug("TIMER: Spammer check - Average cycles: ", (measurement / spammerIterations),
             " (Threshold: ", spammerAvgThreshold, ")");
 #endif
-
         if (spammerDetected) {
             restoreThreadPriority();
             return true;
         }
 
 #if (WINDOWS)
-        // --- 4.  QPC Check ---
+        // --- 4. QPC Check ---
         // Compare trapping vs non-trapping instruction timing
         LARGE_INTEGER startQPC, endQPC;
         QueryPerformanceCounter(&startQPC);
@@ -8102,7 +7969,7 @@ private: // START OF PRIVATE VM DETECTION TECHNIQUE DEFINITIONS
         }
 
         QueryPerformanceCounter(&endQPC);
-        LONGLONG dummyTime = endQPC.QuadPart - startQPC.QuadPart;
+        const LONGLONG dummyTime = endQPC.QuadPart - startQPC.QuadPart;
 
         const bool qpcCheck = (dummyTime != 0) && ((cpuIdTime / dummyTime) > qpcRatioThreshold);
 #ifdef __VMAWARE_DEBUG__
@@ -8112,87 +7979,100 @@ private: // START OF PRIVATE VM DETECTION TECHNIQUE DEFINITIONS
             " (Threshold: ", qpcRatioThreshold,
             ')');
 #endif
+        restoreThreadPriority();
 
         if (qpcCheck) {
-            restoreThreadPriority();
             return true;
         }
+#endif
+        bool tscSyncDetected = false;
 
-        // --- 5. TSC Synchronization Check Across Cores ---
-        // Try reading the invariant TSC on two different cores to attempt to detect vCPU timers being shared
-        const bool tscSyncDetected = [&]() noexcept -> bool {
-            int tscIssueCount = 0;
-            u64 tscCore1 = 0, tscCore2 = 0;
-            for (int i = 0; i < tscIterations; i++) {
-                unsigned int aux = 0;
-
-                try {
 #if (WINDOWS)
-                    DWORD_PTR oldAffinity = SetThreadAffinityMask(GetCurrentThread(), 1);
-                    tscCore1 = __rdtscp(&aux);
-                    SetThreadAffinityMask(GetCurrentThread(), 2);
-                    tscCore2 = __rdtscp(&aux);
-                    SetThreadAffinityMask(GetCurrentThread(), oldAffinity);
+        const DWORD_PTR oldTscAffinity = SetThreadAffinityMask(GetCurrentThread(), static_cast<DWORD_PTR>(~0));
 #elif (LINUX)
-                    cpu_set_t origSet;
-                    pthread_getaffinity_np(pthread_self(), sizeof(cpu_set_t), &origSet);
-
-                    // Core 0
-                    cpu_set_t set;
-                    CPU_ZERO(&set);
-                    CPU_SET(0, &set);
-                    pthread_setaffinity_np(pthread_self(), sizeof(cpu_set_t), &set);
-                    tscCore1 = __rdtscp(&aux);
-
-                    // Core 1
-                    CPU_ZERO(&set);
-                    CPU_SET(1, &set);
-                    pthread_setaffinity_np(pthread_self(), sizeof(cpu_set_t), &set);
-                    tscCore2 = __rdtscp(&aux);
-
-                    pthread_setaffinity_np(pthread_self(), sizeof(cpu_set_t), &origSet);
+        cpu_set_t oldTscSet;
+        CPU_ZERO(&oldTscSet);
+        pthread_getaffinity_np(pthread_self(), sizeof(cpu_set_t), &oldTscSet);
 #endif
-                }
-                catch (...) {
-                    tscIssueCount++;
-                    continue;
+
+
+        if (!singleCore) {
+            // --- 5. TSC Synchronization Check Across Cores ---
+            // Try reading the invariant TSC on two different cores to attempt to detect vCPU timers being shared
+            tscSyncDetected = [&]() noexcept -> bool {
+                int tscIssueCount = 0;
+                u64 tscCore1 = 0, tscCore2 = 0;
+
+                for (int i = 0; i < tscIterations; i++) {
+                    unsigned int aux = 0;
+
+                    try {
+#if (WINDOWS)
+                        SetThreadAffinityMask(GetCurrentThread(), 1);
+                        tscCore1 = __rdtscp(&aux);
+                        SetThreadAffinityMask(GetCurrentThread(), 2);
+                        tscCore2 = __rdtscp(&aux);
+#elif (LINUX)
+                        // Core 0
+                        cpu_set_t set;
+                        CPU_ZERO(&set);
+                        CPU_SET(0, &set);
+                        pthread_setaffinity_np(pthread_self(), sizeof(cpu_set_t), &set);
+                        tscCore1 = __rdtscp(&aux);
+
+                        // Core 1
+                        CPU_ZERO(&set);
+                        CPU_SET(1, &set);
+                        pthread_setaffinity_np(pthread_self(), sizeof(cpu_set_t), &set);
+                        tscCore2 = __rdtscp(&aux);
+#endif
+                    }
+                    catch (...) {
+                        tscIssueCount++; // __rdtscp should be supported on most systems
+                        continue;
+                    }
+
+                    // hypervisors often have nearly identical TSCs across vCPUs
+                    const u64 diff = (tscCore2 > tscCore1)
+                        ? (tscCore2 - tscCore1)
+                        : (tscCore1 - tscCore2);
+
+                    if (diff < tscSyncDiffThreshold) {
+                        tscIssueCount++;
+                    }
                 }
 
-                // hypervisors often have nearly identical TSCs across vCPUs
-                const u64 diff = (tscCore2 > tscCore1)
-                    ? (tscCore2 - tscCore1)
-                    : (tscCore1 - tscCore2);
-
-                if (diff < tscSyncDiffThreshold) { 
-                    tscIssueCount++;
-                }
-            }
 #ifdef __VMAWARE_DEBUG__
-            debug("TIMER: TSC sync check",
-                " - Core1: ", tscCore1,
-                " Core2: ", tscCore2,
-                " Delta: ", tscCore2 - tscCore1,
-                " (Threshold: <", tscSyncDiffThreshold,
-                ')');
+                debug("TIMER: TSC sync check",
+                    " - Core1: ", tscCore1,
+                    " Core2: ", tscCore2,
+                    " Delta: ", tscCore2 - tscCore1,
+                    " (Threshold: <", tscSyncDiffThreshold,
+                    ')');
 #endif
-            return (tscIssueCount >= tscIterations / 2);
-            }();
+
+                return (tscIssueCount >= tscIterations / 2);
+                }();
+        }
+
+#if (WINDOWS)
+        SetThreadAffinityMask(GetCurrentThread(), oldTscAffinity);
+#elif (LINUX)
+        pthread_setaffinity_np(pthread_self(), sizeof(cpu_set_t), &oldTscSet);
+#endif
 
         if (tscSyncDetected) {
-            restoreThreadPriority();
             return true;
         }
-#endif // WINDOWS
 
-        restoreThreadPriority();
         return false;
 #endif
     }
-#if defined(MSVC)
+#if (MSVC)
     #pragma optimize("", on)
-#elif defined(CLANG)
+#elif (CLANG)
     #pragma clang optimize on
-#elif defined(GCC)
+#elif (GCC)
     #pragma GCC pop_options
 #endif
 
@@ -9332,22 +9212,14 @@ private: // START OF PRIVATE VM DETECTION TECHNIQUE DEFINITIONS
             { "z2 go ", 8 }
         } };
 
-        bool mismatch = false;
-        bool found = false;
-
         for (const auto& pair : amd_thread_database) {
             if (model.find(pair.first) != std::string::npos) {
-                mismatch = (std::thread::hardware_concurrency() != static_cast<unsigned>(pair.second));
-                found = true;
-                break;
+                debug("AMD_THREAD_MISMATCH: Found CPU in database with ", pair.second, " threads");
+                return std::thread::hardware_concurrency() != static_cast<unsigned>(pair.second);
             }
         }
 
-        if (found) {
-            debug("AMD_THREAD_MISMATCH: Unknown brand found for AMD = ", model);
-        }
-
-        return mismatch;
+        return false;
 #endif
 	}
 
@@ -9914,6 +9786,7 @@ private: // START OF PRIVATE VM DETECTION TECHNIQUE DEFINITIONS
 
     /*
      * @brief Check if running xgetbv in the XCR0 extended feature register triggers an exception
+     * @note On pre‑Win8, CR4.OSXSAVE may only get set if you’ve actually loaded an AVX‑enabled binary
      * @category Windows
      * @implements VM::OSXSAVE
      */
@@ -9941,6 +9814,7 @@ private: // START OF PRIVATE VM DETECTION TECHNIQUE DEFINITIONS
             func();
         }
         __except (EXCEPTION_EXECUTE_HANDLER) {
+            VirtualFree(mem, 0, MEM_RELEASE);
             return true;
         }
 
@@ -11267,7 +11141,6 @@ public: // START OF PUBLIC FUNCTIONS
             case DMIDECODE: return "DMIDECODE";
             case DMESG: return "DMESG";
             case HWMON: return "HWMON";
-            case SIDT5: return "SIDT5";
             case DLL: return "DLL";
             case REGISTRY: return "REGISTRY";
             case VM_FILES: return "VM_FILES";
@@ -11296,10 +11169,6 @@ public: // START OF PUBLIC FUNCTIONS
             case SIDT: return "SIDT";
             case SGDT: return "SGDT";
             case SLDT: return "SLDT";
-            case OFFSEC_SIDT: return "OFFSEC_SIDT";
-            case OFFSEC_SGDT: return "OFFSEC_SGDT";
-            case OFFSEC_SLDT: return "OFFSEC_SLDT";
-            case VPC_SIDT: return "VPC_SIDT";
             case VMWARE_IOMEM: return "VMWARE_IOMEM";
             case VMWARE_IOPORTS: return "VMWARE_IOPORTS";
             case VMWARE_SCSI: return "VMWARE_SCSI";
@@ -11337,7 +11206,6 @@ public: // START OF PUBLIC FUNCTIONS
             case PODMAN_FILE: return "PODMAN_FILE";
             case WSL_PROC: return "WSL_PROC";
             case DRIVER_NAMES: return "DRIVER_NAMES";
-            case VM_SIDT: return "VM_SIDT";
             case DISK_SERIAL: return "DISK_SERIAL";
             case PORT_CONNECTORS: return "PORT_CONNECTORS";
             case GPU_VM_STRINGS: return "GPU_STRINGS";
@@ -11826,7 +11694,6 @@ std::pair<VM::enum_flags, VM::core::technique> VM::core::technique_list[] = {
     std::make_pair(VM::DMIDECODE, VM::core::technique(55, VM::dmidecode)),
     std::make_pair(VM::DMESG, VM::core::technique(55, VM::dmesg)),
     std::make_pair(VM::HWMON, VM::core::technique(35, VM::hwmon)),
-    std::make_pair(VM::SIDT5, VM::core::technique(45, VM::sidt5)),
     std::make_pair(VM::DLL, VM::core::technique(25, VM::dll_check)),
     std::make_pair(VM::REGISTRY, VM::core::technique(50, VM::registry_key)),
     std::make_pair(VM::VM_FILES, VM::core::technique(25, VM::vm_files)),
@@ -11855,10 +11722,6 @@ std::pair<VM::enum_flags, VM::core::technique> VM::core::technique_list[] = {
     std::make_pair(VM::SIDT, VM::core::technique(25, VM::sidt)),
     std::make_pair(VM::SGDT, VM::core::technique(30, VM::sgdt)),
     std::make_pair(VM::SLDT, VM::core::technique(15, VM::sldt)),
-    std::make_pair(VM::OFFSEC_SIDT, VM::core::technique(60, VM::offsec_sidt)),
-    std::make_pair(VM::OFFSEC_SGDT, VM::core::technique(60, VM::offsec_sgdt)),
-    std::make_pair(VM::OFFSEC_SLDT, VM::core::technique(20, VM::offsec_sldt)),
-    std::make_pair(VM::VPC_SIDT, VM::core::technique(15, VM::vpc_sidt)),
     std::make_pair(VM::VMWARE_IOMEM, VM::core::technique(65, VM::vmware_iomem)),
     std::make_pair(VM::VMWARE_IOPORTS, VM::core::technique(70, VM::vmware_ioports)),
     std::make_pair(VM::VMWARE_SCSI, VM::core::technique(40, VM::vmware_scsi)),
@@ -11897,7 +11760,6 @@ std::pair<VM::enum_flags, VM::core::technique> VM::core::technique_list[] = {
     std::make_pair(VM::PODMAN_FILE, VM::core::technique(5, VM::podman_file)),
     std::make_pair(VM::WSL_PROC, VM::core::technique(30, VM::wsl_proc_subdir)),
     std::make_pair(VM::DRIVER_NAMES, VM::core::technique(100, VM::driver_names)),
-    std::make_pair(VM::VM_SIDT, VM::core::technique(100, VM::vm_sidt)),
     std::make_pair(VM::DISK_SERIAL, VM::core::technique(100, VM::disk_serial_number)),
     std::make_pair(VM::PORT_CONNECTORS, VM::core::technique(25, VM::port_connectors)),
     std::make_pair(VM::GPU_VM_STRINGS, VM::core::technique(100, VM::gpu_vm_strings)),

--- a/src/vmaware_MIT.hpp
+++ b/src/vmaware_MIT.hpp
@@ -24,21 +24,21 @@
  *  - Docs: https://github.com/kernelwernel/VMAware/docs/documentation.md
  *  - Full credits: https://github.com/kernelwernel/VMAware#credits-and-contributors-%EF%B8%8F
  *  - License: MIT
- * 
+ *
  *                               MIT License
- *  
+ *
  *  Copyright (c) 2025 kernelwernel
- *  
+ *
  *  Permission is hereby granted, free of charge, to any person obtaining a copy
  *  of this software and associated documentation files (the "Software"), to deal
  *  in the Software without restriction, including without limitation the rights
  *  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
  *  copies of the Software, and to permit persons to whom the Software is
  *  furnished to do so, subject to the following conditions:
- *  
+ *
  *  The above copyright notice and this permission notice shall be included in all
  *  copies or substantial portions of the Software.
- *  
+ *
  *  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
  *  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
  *  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
@@ -49,34 +49,34 @@
  *
  *
  * ============================== SECTIONS ==================================
- * - enums for publicly accessible techniques  => line 578
- * - struct for internal cpu operations        => line 762
- * - struct for internal memoization           => line 1233
- * - struct for internal utility functions     => line 1357
- * - struct for internal core components       => line 9857
- * - start of VM detection technique list      => line 2384
- * - start of public VM detection functions    => line 10521
- * - start of externally defined variables     => line 11462
+ * - enums for publicly accessible techniques  => line 555
+ * - struct for internal cpu operations        => line 754
+ * - struct for internal memoization           => line 1226
+ * - struct for internal utility functions     => line 1351
+ * - struct for internal core components       => line 9756
+ * - start of VM detection technique list      => line 2380
+ * - start of public VM detection functions    => line 10431
+ * - start of externally defined variables     => line 11372
  *
  *
  * ============================== EXAMPLE ===================================
  * #include "vmaware.hpp"
  * #include <iostream>
- * 
+ *
  * int main() {
  *     if (VM::detect()) {
  *         std::cout << "Virtual machine detected!" << "\n";
  *     } else {
  *         std::cout << "Running on baremetal" << "\n";
  *     }
- * 
+ *
  *     std::cout << "VM name: " << VM::brand() << "\n";
  *     std::cout << "VM type: " << VM::type() << "\n";
  *     std::cout << "VM certainty: " << (int)VM::percentage() << "%" << "\n";
  * }
- * 
  *
- * ========================== CODE DOCUMENTATION =============================
+ *
+  * ========================== CODE DOCUMENTATION =============================
  * 
  * Welcome! This is just a preliminary text to lay the context of how it works, 
  * how it's structured, and guide anybody who's trying to understand the whole code. 
@@ -91,12 +91,12 @@
  *  - the TECHNIQUE table stores all the VM detection technique information in a std::map 
  * 
  *  - the BRAND table stores every VM brand as a std::map as well, but as a scoreboard. 
- *    This mean that if a VM detection has detected a VM brand, that brand will have an
+ *    This means that if a VM detection has detected a VM brand, that brand will have an
  *    incremented score. After every technique is run, the brand with the highest score
  *    is chosen as the officially detected brand. 
  * 
  * The techniques are all static functions, which all return a boolean. There are a few 
- * categories of techniques that target vastly different things such as OS queires, CPU
+ * categories of techniques that target vastly different things such as OS queries, CPU
  * values, other hardware values, firmware data, and system files just to name a few. 
  * 
  * 
@@ -119,7 +119,7 @@
  *        confused with "memorization"). More specifically, this allows us to cache 
  *        a technique result in a table where each entry contains a technique and its
  *        result. This allows us to avoid re-running techniques which happens a lot
- *        internally. Some techniques are more costlier than others in terms of 
+ *        internally. Some techniques are costlier than others in terms of 
  *        performance, so this is a crucial module that allows us to save a lot of
  *        time. Additionally, it contains other memoization caches for various other
  *        things for convenience purposes. 
@@ -138,7 +138,7 @@
  *    1. The function tries to handle the user arguments (if there's 
  *       any), and generates a std::bitset. This bitset has a length of 
  *       every VM detection technique + settings, where each bit 
- *       corresponds to whether this technique will be ran or not, 
+ *       corresponds to whether this technique will be run or not, 
  *       and which settings were selected. 
  * 
  *    2. After the bitset has been generated, this information is then 
@@ -154,7 +154,7 @@
  *       If it hasn't, run the technique and cache the result to the 
  *       cache table. 
  * 
- *    4. After every technique has been looped through, this generates a 
+ *    4. After every technique has been executed, this generates a 
  *       uint16_t score. Every technique has a score value between 0 to 
  *       100, and if they are detected then this score is accumulated to 
  *       a total score. If the total is above 150, that means it's a VM[1]. 
@@ -169,7 +169,7 @@
  *       important is because a lot of techniques increment a point for its 
  *       respected brand that was detected. For example, if the VM::QEMU_USB
  *       technique has detected a VM, it'll add a score to the QEMU brand in
- *       the scoreboard. If no technique has been ran, then there's no way to
+ *       the scoreboard. If no technique has been run, then there's no way to
  *       populate the scoreboard with any points. After every VM detection 
  *       technique has been invoked/retrieved, the brand scoreboard is now
  *       ready to be analysed.
@@ -192,8 +192,8 @@
  *       output of the VM::brand() function.
  * 
  *    6. The result is then cached to the memo module, so if another function
- *       invokes VM:brand() again, the result is retrieved from the cache
- *       without having it run all of the previous steps mentioned.
+ *       invokes VM:brand() again, "the result is retrieved from the cache 
+ *       without needing to run all of the previous steps again.
  *      
  * (NOTE: it's a bit more complicated than this, but that's the gist of how this function works)
  * 
@@ -201,7 +201,7 @@
  * And they serve as a functionality base for other components of the lib.
  *      
  *  
- *  [1]: If the user has inputted a setting argument called VM::HIGH_THRESHOLD, 
+ *  [1]: If the user has provided a setting argument called VM::HIGH_THRESHOLD, 
  *       the threshold becomes 300 instead of 150.
  */
 
@@ -390,9 +390,9 @@
 #include <mmsystem.h>
 #include <dxgi.h>
 #include <d3d9.h>
+#include <d3d11.h>
+#include <d3d12.h>
 
-#pragma comment(lib, "dxgi.lib")
-#pragma comment(lib, "d3d9.lib")
 #pragma comment(lib, "winmm.lib")
 #pragma comment(lib, "setupapi.lib")
 #pragma comment(lib, "iphlpapi.lib")
@@ -405,6 +405,10 @@
 #pragma comment(lib, "uuid.lib")
 #pragma comment(lib, "ntdll.lib")
 #pragma comment(lib, "powrprof.lib")
+#pragma comment(lib, "d3d9.lib")
+#pragma comment(lib, "d3d11.lib")
+#pragma comment(lib, "d3d12.lib")
+#pragma comment(lib, "dxgi.lib")
 
 #elif (LINUX)
 #if (x86)
@@ -486,7 +490,7 @@ MSVC_DISABLE_WARNING(ASSIGNMENT_OPERATOR NO_INLINE_FUNC SPECTRE)
  *
  * TL;DR I have wonky fingers :(
  */
-namespace brands {
+    namespace brands {
     static constexpr const char* NULL_BRAND = "Unknown";
     static constexpr const char* VBOX = "VirtualBox";
     static constexpr const char* VMWARE = "VMware";
@@ -560,11 +564,11 @@ namespace brands {
 
 struct VM {
 private:
-    using u8  = std::uint8_t;
+    using u8 = std::uint8_t;
     using u16 = std::uint16_t;
     using u32 = std::uint32_t;
     using u64 = std::uint64_t;
-    using i8  = std::int8_t;
+    using i8 = std::int8_t;
     using i16 = std::int16_t;
     using i32 = std::int32_t;
     using i64 = std::int64_t;
@@ -586,7 +590,6 @@ public:
         DMIDECODE,
         DMESG,
         HWMON,
-        SIDT5,
         DLL,
         REGISTRY,
         VM_FILES,
@@ -608,10 +611,6 @@ public:
         SIDT,
         SGDT,
         SLDT,
-        OFFSEC_SIDT,
-        OFFSEC_SGDT,
-        OFFSEC_SLDT,
-        VPC_SIDT,
         VMWARE_IOMEM,
         VMWARE_IOPORTS,
         VMWARE_SCSI,
@@ -649,7 +648,6 @@ public:
         PODMAN_FILE,
         WSL_PROC,
         DRIVER_NAMES,
-        VM_SIDT,
         DISK_SERIAL,
         PORT_CONNECTORS,
         GPU_VM_STRINGS,
@@ -709,7 +707,7 @@ private:
 
     // this is specifically meant for VM::detected_count() to 
     // get the total number of techniques that detected a VM
-    static u8 detected_count_num; 
+    static u8 detected_count_num;
 
 private:
 
@@ -733,7 +731,7 @@ public:
 
 private:
     // macro for bypassing unused parameter/variable warnings
-    #define UNUSED(x) ((void)(x))
+#define UNUSED(x) ((void)(x))
 
 // likely and unlikely macros
 #if (LINUX)
@@ -922,11 +920,11 @@ private:
             constexpr std::size_t buffer_size = sizeof(int32_t) * buffer.size();
             std::array<char, 64> charbuffer{};
 
-            constexpr std::array<u32, 3> ids = {{
+            constexpr std::array<u32, 3> ids = { {
                 cpu::leaf::brand1,
                 cpu::leaf::brand2,
                 cpu::leaf::brand3
-            }};
+            } };
 
             std::string brand = "";
 
@@ -1024,7 +1022,7 @@ private:
                 steps.model == celeron_model &&
                 steps.family == celeron_family &&
                 steps.extmodel == celeron_extmodel
-            );
+                );
         }
 
 
@@ -1061,7 +1059,7 @@ private:
                 }
 
                 return false;
-            };
+                };
 
             bool found = false;
             bool is_xeon = false;
@@ -1072,7 +1070,8 @@ private:
                 if (match(intel_i_series_regex)) {
                     found = true;
                     is_i_series = true;
-                } else if (match(intel_xeon_series_regex)) {
+                }
+                else if (match(intel_xeon_series_regex)) {
                     found = true;
                     is_xeon = true;
                 }
@@ -1221,7 +1220,7 @@ private:
 
             return false;
         }
-    };
+        };
 
     // memoization
     struct memo {
@@ -1271,10 +1270,11 @@ private:
         static bool all_present() {
             if (cache_table.size() == technique_count) {
                 return true;
-            } else if (cache_table.size() == static_cast<std::size_t>(technique_count) - 3) {
+            }
+            else if (cache_table.size() == static_cast<std::size_t>(technique_count) - 3) {
                 return (
                     !cache_keys.test(VMWARE_DMESG)
-                );
+                    );
             }
 
             return false;
@@ -1361,7 +1361,8 @@ private:
                 if (home) {
                     path = std::string(home) + raw_path_str.substr(1);
                 }
-            } else {
+            }
+            else {
                 path = raw_path;
             }
 
@@ -1461,7 +1462,7 @@ private:
             return (
                 (uid != euid) ||
                 (euid == 0)
-            );
+                );
 #elif (WINDOWS)
             BOOL is_admin = FALSE;
             HANDLE hToken = NULL;
@@ -1485,7 +1486,7 @@ private:
                 }
             }
 
-            CloseHandle(hToken); 
+            CloseHandle(hToken);
 
             return is_admin;
 #endif
@@ -1691,7 +1692,7 @@ private:
 
             if (size == 0)
                 return 81;
-            
+
             return size;  // Return disk size in GB
         }
 
@@ -1725,7 +1726,8 @@ private:
                 if (std::isdigit(c)) {
                     number_str += c;
                     in_number = true;
-                } else if (in_number) {
+                }
+                else if (in_number) {
                     break;
                 }
             }
@@ -1884,7 +1886,7 @@ private:
 #else
             return false;
 #endif
-        }
+            }
 
         // Returns a list of running process names
         [[nodiscard]] static std::unordered_set<std::string> get_running_process_names() {
@@ -1932,7 +1934,6 @@ private:
             return std::string();
         }
 
-
         /**
          * @brief Checks whether the system is running in a Hyper-V virtual machine or if the host system has Hyper-V enabled
          * @note Hyper-V's presence on a host system can set certain hypervisor-related CPU flags that may appear similar to those in a virtualized environment, which can make it challenging to differentiate between an actual Hyper-V virtual machine (VM) and a host system with Hyper-V enabled.
@@ -1979,12 +1980,12 @@ private:
             /**
               * On Hyper-V virtual machines, the cpuid function reports an EAX value of 11
               * This value is tied to the Hyper-V partition model, where each virtual machine runs as a child partition
-              * These child partitions have limited privileges and access to hypervisor resources, 
+              * These child partitions have limited privileges and access to hypervisor resources,
               * which is reflected in the maximum input value for hypervisor CPUID information as 11.
               * Essentially, it indicates that the hypervisor is managing the VM and that the VM is not running directly on hardware but rather in a virtualized environment
             */
             auto eax = []() -> u32 {
-                char out[sizeof(int32_t) * 4 + 1] = { 0 }; 
+                char out[sizeof(int32_t) * 4 + 1] = { 0 };
                 cpu::cpuid((int*)out, cpu::leaf::hypervisor);
 
                 const u32 eax = static_cast<u32>(out[0]);
@@ -2007,6 +2008,7 @@ private:
                 }
             }
             else {
+                // normally eax 12
                 const std::string brand_str = cpu::cpu_manufacturer(0x40000001);
 
                 if (util::find(brand_str, "KVM")) {
@@ -2372,7 +2374,7 @@ private:
             }
         }
 #endif
-    };
+        };
 
 
 private: // START OF PRIVATE VM DETECTION TECHNIQUE DEFINITIONS
@@ -2389,7 +2391,7 @@ private: // START OF PRIVATE VM DETECTION TECHNIQUE DEFINITIONS
             cpu::vmid_template(0) ||
             cpu::vmid_template(cpu::leaf::hypervisor) || // 0x40000000
             cpu::vmid_template(cpu::leaf::hypervisor + 0x100) // 0x40000100
-        );
+            );
 #endif
     }
 
@@ -2568,7 +2570,8 @@ private: // START OF PRIVATE VM DETECTION TECHNIQUE DEFINITIONS
 
         if (success) {
             std::memcpy(mac, ifr.ifr_hwaddr.sa_data, 6);
-        } else {
+        }
+        else {
             debug("MAC: ", "not successful");
         }
 #elif (WINDOWS)
@@ -2597,7 +2600,7 @@ private: // START OF PRIVATE VM DETECTION TECHNIQUE DEFINITIONS
             << static_cast<int32_t>(mac[1]) << ":"
             << static_cast<int32_t>(mac[2]) << ":XX:XX:XX";
         /* removed for privacy reasons, only the first 3 bytes are needed
-            << static_cast<int32_t>(mac[3]) << ":"  
+            << static_cast<int32_t>(mac[3]) << ":"
             << static_cast<int32_t>(mac[4]) << ":"
             << static_cast<int32_t>(mac[5]);
         */
@@ -2721,7 +2724,8 @@ private: // START OF PRIVATE VM DETECTION TECHNIQUE DEFINITIONS
 
         if (util::exists(chassis)) {
             return (stoi(util::read_file(chassis)) == 1);
-        } else {
+        }
+        else {
             debug("CTYPE: ", "file doesn't exist");
         }
 
@@ -2772,15 +2776,20 @@ private: // START OF PRIVATE VM DETECTION TECHNIQUE DEFINITIONS
         if (*result == "" || result == nullptr) {
             debug("DMIDECODE: ", "invalid output");
             return false;
-        } else if (*result == "QEMU") {
+        }
+        else if (*result == "QEMU") {
             return core::add(brands::QEMU);
-        } else if (*result == "VirtualBox") {
+        }
+        else if (*result == "VirtualBox") {
             return core::add(brands::VBOX);
-        } else if (*result == "KVM") {
+        }
+        else if (*result == "KVM") {
             return core::add(brands::KVM);
-        } else if (std::atoi(result->c_str()) >= 1) {
+        }
+        else if (std::atoi(result->c_str()) >= 1) {
             return true;
-        } else {
+        }
+        else {
             debug("DMIDECODE: ", "output = ", *result);
         }
 
@@ -2811,13 +2820,17 @@ private: // START OF PRIVATE VM DETECTION TECHNIQUE DEFINITIONS
 
         if (*result == "" || result == nullptr) {
             return false;
-        } else if (*result == "KVM") {
+        }
+        else if (*result == "KVM") {
             return core::add(brands::KVM);
-        } else if (*result == "QEMU") {
+        }
+        else if (*result == "QEMU") {
             return core::add(brands::QEMU);
-        } else if (std::atoi(result->c_str())) {
+        }
+        else if (std::atoi(result->c_str())) {
             return true;
-        } else {
+        }
+        else {
             debug("DMESG: ", "output = ", *result);
         }
 
@@ -2841,13 +2854,15 @@ private: // START OF PRIVATE VM DETECTION TECHNIQUE DEFINITIONS
 
 
     /**
-     * @brief Check if the 5th byte after sidt is null
-     * @author Matteo Malvica
-     * @link https://www.matteomalvica.com/blog/2018/12/05/detecting-vmware-on-64-bit-systems/
-     * @category Linux
-     * @implements VM::SIDT5
+     * @brief Check for uncommon IDT virtual addresses
+     * @author Matteo Malvica (Linux)
+     * @link https://www.matteomalvica.com/blog/2018/12/05/detecting-vmware-on-64-bit-systems/ (Linux)
+     * @note Idea to check VPC's range from Tom Liston and Ed Skoudis' paper "On the Cutting Edge: Thwarting Virtual Machine Detection" (Windows)
+     * @note Paper situated at /papers/ThwartingVMDetection_Liston_Skoudis.pdf (Windows)
+     * @category Windows, Linux
+     * @implements VM::SIDT
      */
-    [[nodiscard]] static bool sidt5() {
+    [[nodiscard]] static bool sidt() {
 #if (LINUX && (GCC || CLANG))
         u8 values[10] = { 0 };
 
@@ -2885,8 +2900,41 @@ private: // START OF PRIVATE VM DETECTION TECHNIQUE DEFINITIONS
         return false;
 #endif
 
+#elif (WINDOWS)
+        unsigned char m[6] = { 0 };
+        u32	idt = 0;
+
+        __try {
+#if (CLANG || GCC)
+            __asm__ volatile ("sidt %0" : "=m"(m));
+#elif (MSVC && x86_32)
+            __asm {
+                sidt m
+            }
+#elif (MSVC)
+#pragma pack(push, 1)
+            struct {
+                unsigned short limit;
+                unsigned long long base;
+            } idtr = {};
+#pragma pack(pop)
+
+            __sidt(&idtr);
+            std::memcpy(m, &idtr, sizeof(m));
 #else
-        return false;
+            return false;
+#endif
+        }
+        __except (EXCEPTION_EXECUTE_HANDLER) {
+            return false; // umip
+        }
+        idt = *((unsigned long*)&m[2]);
+
+        if ((idt >> 24) == 0xE8) {
+            return core::add(brands::VPC);
+        }
+
+        return (m[5] > 0xD0); // top‐most byte of the 64‑bit base
 #endif
     }
 
@@ -3346,7 +3394,7 @@ private: // START OF PRIVATE VM DETECTION TECHNIQUE DEFINITIONS
             return false;
         }
 
-    #if (LINUX)
+#if (LINUX)
         auto get_distro = []() -> std::string {
             std::ifstream osReleaseFile("/etc/os-release");
             std::string line;
@@ -3393,7 +3441,7 @@ private: // START OF PRIVATE VM DETECTION TECHNIQUE DEFINITIONS
         }
 
         return false;
-    #elif (WINDOWS)
+#elif (WINDOWS)
         const u8 version = util::get_windows_version();
 
         if (version < 10) {
@@ -3407,7 +3455,7 @@ private: // START OF PRIVATE VM DETECTION TECHNIQUE DEFINITIONS
 
         debug("VBOX_DEFAULT: Windows 11 detected");
         return ((80 == disk) && (4 == ram));
-    #endif
+#endif
 #endif
     }
 
@@ -3433,11 +3481,11 @@ private: // START OF PRIVATE VM DETECTION TECHNIQUE DEFINITIONS
     }
 
 
-     /**
-      * @brief Check for any VM processes that are active
-      * @category Windows
-      * @implements VM::VM_PROCESSES
-      */
+    /**
+     * @brief Check for any VM processes that are active
+     * @category Windows
+     * @implements VM::VM_PROCESSES
+     */
     [[nodiscard]] static bool vm_processes() {
 #if (WINDOWS)
         const auto runningProcesses = util::get_running_process_names();
@@ -3518,7 +3566,7 @@ private: // START OF PRIVATE VM DETECTION TECHNIQUE DEFINITIONS
         return (
             (strcmp(username, "liveuser") == 0) &&
             (strcmp(hostname, "localhost-live") == 0)
-        );
+            );
 #endif
     }
 
@@ -3606,7 +3654,8 @@ private: // START OF PRIVATE VM DETECTION TECHNIQUE DEFINITIONS
                 debug("BOCHS_CPU: technique 1 found");
                 return core::add(brands::BOCHS);
             }
-        } else if (amd) {
+        }
+        else if (amd) {
             // technique 2: "processor" should have a capital P
             if (brand == "AMD Athlon(tm) processor") {
                 debug("BOCHS_CPU: technique 2 found");
@@ -3635,7 +3684,7 @@ private: // START OF PRIVATE VM DETECTION TECHNIQUE DEFINITIONS
                 }
 
                 return false;
-            };
+                };
 
             auto is_k8 = [](const u32 eax) -> bool {
                 const u32 family = (eax >> 8) & 0xF;
@@ -3648,7 +3697,7 @@ private: // START OF PRIVATE VM DETECTION TECHNIQUE DEFINITIONS
                 }
 
                 return false;
-            };
+                };
 
             if (!(is_k7(eax) || is_k8(eax))) {
                 return false;
@@ -3978,13 +4027,13 @@ private: // START OF PRIVATE VM DETECTION TECHNIQUE DEFINITIONS
             }
 
             return false;
-        };
+            };
 
         return (
             check_usb() ||
             check_general() ||
             check_rom()
-        );
+            );
 #endif
     }
 
@@ -4126,13 +4175,11 @@ private: // START OF PRIVATE VM DETECTION TECHNIQUE DEFINITIONS
 
     /**
      * @brief Check for official VPC method
-     * @category Windows, x86
+     * @category Windows, x86_32
      * @implements VM::VPC_INVALID
      */
     [[nodiscard]] static bool vpc_invalid() {
-#if (!WINDOWS || !x86_64)
-        return false;
-#elif (x86_32)
+#if (WINDOWS && x86_32)
         bool rc = false;
 
         auto IsInsideVPC_exceptionFilter = [](PEXCEPTION_POINTERS ep) -> DWORD {
@@ -4180,79 +4227,46 @@ private: // START OF PRIVATE VM DETECTION TECHNIQUE DEFINITIONS
 
 
     /**
-     * @brief Check for sidt instruction method
-     * @category Linux, Windows, x86
-     * @implements VM::SIDT
-     */
-    [[nodiscard]] static bool sidt() {
-#if (!WINDOWS)
-        return false;
-#else
-        u8 idtr[10]{};
-        u32 idt_entry = 0;
-
-#   if (x86_32)
-        __try {
-#           if (CLANG || GCC)
-                __asm__ volatile("sidt %0" : "=m"(idtr));
-#           else
-                _asm sidt idtr
-#           endif
-        }
-        __except (EXCEPTION_EXECUTE_HANDLER) {
-            return false;  // UMIP
-        }
-#   elif (x86_64)
-#       pragma pack(push, 1)
-        struct IDTR {
-            u16 limit;
-            u64 base;
-        };
-#       pragma pack(pop)
-
-        IDTR idtrStruct = {};
-        __try {
-#           if (CLANG || GCC)
-                __asm__ volatile("sidt %0" : "=m"(idtrStruct));
-#           else
-                __sidt(&idtrStruct);
-#           endif
-        }
-        __except (EXCEPTION_EXECUTE_HANDLER) {
-            return false;
-        }
-        std::memcpy(idtr, &idtrStruct, sizeof(idtr));
-#   else
-        return false;
-#   endif
-
-        idt_entry = *reinterpret_cast<unsigned long*>(&idtr[2]);
-        return ((idt_entry >> 24) == 0xFF) ? core::add(brands::VMWARE) : false;
-#endif
-    }
-
-
-    /**
      * @brief Check for sgdt instruction method
-     * @category Windows, x86
+     * @category Windows
+     * @author Danny Quist (chamuco@gmail.com) (top-most byte signature)
+     * @author Val Smith (mvalsmith@metasploit.com) (top-most byte signature)
+     * @note code documentation paper in /papers/www.offensivecomputing.net_vm.pdf (top-most byte signature)
      * @implements VM::SGDT
      */
     [[nodiscard]] static bool sgdt() {
-#if defined(_M_IX86) && defined(_WIN32)
-        
-            unsigned char gdtr[6] = { 0 };
-            unsigned int gdt = 0;
+#if (WINDOWS)
+        unsigned char gdtr[6] = { 0 };
+        unsigned int  gdt = 0;
+
         __try {
+#if (CLANG || GCC)
+            __asm__ volatile("sgdt %0" : "=m"(gdtr));
+#elif (MSVC && x86_32)
             __asm {
                 sgdt gdtr
             }
-            gdt = *reinterpret_cast<unsigned int*>(&gdtr[2]);
-            return ((gdt >> 24) == 0xFF);
+#elif (MSVC)
+#pragma pack(push, 1)
+            struct { unsigned short limit; unsigned long long base; } _gdtr = {};
+#pragma pack(pop)
+            _sgdt(&_gdtr);
+            std::memcpy(gdtr, &_gdtr, sizeof(gdtr));
+#else
+            return false;
+#endif
         }
         __except (EXCEPTION_EXECUTE_HANDLER) {
-            // umip
-            return false;
+            return false; // umip
         }
+
+        std::memcpy(&gdt, &gdtr[2], sizeof(gdt));
+
+        if (gdtr[5] > 0xD0) { // top‐most byte of the 64‑bit base
+            debug("SGDT: top-most byte signature detected");
+            return true;
+        }
+        return ((gdt >> 24) == 0xFF);
 #else
         return false;
 #endif
@@ -4261,137 +4275,39 @@ private: // START OF PRIVATE VM DETECTION TECHNIQUE DEFINITIONS
 
     /**
      * @brief Check for sldt instruction method
-     * @category Windows, x86
-     * @note code documentation paper in https://www.aldeid.com/wiki/X86-assembly/Instructions/sldt
+     * @category Windows, x86_32
+     * @author Danny Quist (chamuco@gmail.com), ldtr_buf signature
+     * @author Val Smith (mvalsmith@metasploit.com), ldtr_buf signature
+     * @note code documentation paper in /papers/www.offensivecomputing.net_vm.pdf for ldtr_buf signature
+     * @note code documentation paper in https://www.aldeid.com/wiki/X86-assembly/Instructions/sldt for ldt signature
      * @implements VM::SLDT
      */
     [[nodiscard]] static bool sldt() {
-#if (!MSVC && WINDOWS)
-        unsigned char ldtr[5] = "\xef\xbe\xad\xde";
+#if (WINDOWS && x86_32)
+        unsigned char ldtr_buf[4] = { 0xEF, 0xBE, 0xAD, 0xDE };
         unsigned long ldt = 0;
+
         __try {
+#if (CLANG || GCC)
+            __asm__ volatile("sldt %0" : "=m"(*(unsigned short*)ldtr_buf));
+#elif (MSVC)
             __asm {
-                sldt word ptr ldtr  // 'word ptr' to indicate that we're working with a 16-bit value and avoid compiler warnings
+                sldt ax
+                mov  word ptr[ldtr_buf], ax
             }
-        }
-        __except (EXCEPTION_EXECUTE_HANDLER) {
-            // umip
-            return false;
-        }
-
-        ldt = *((unsigned long*)&ldtr[0]);
-
-        return (ldt != 0xdead0000);
-#else
-        return false;
 #endif
-    }
-
-
-    /**
-     * @brief Check for Offensive Security sidt method
-     * @category Windows, x86
-     * @author Danny Quist (chamuco@gmail.com)
-     * @author Val Smith (mvalsmith@metasploit.com)
-     * @note code documentation paper in /papers/www.offensivecomputing.net_vm.pdf
-     * @implements VM::OFFSEC_SIDT
-     */
-    [[nodiscard]] static bool offsec_sidt() {
-#if (!MSVC && WINDOWS)
-        unsigned char m[6]{};
-        __try {
-            __asm sidt m;
         }
         __except (EXCEPTION_EXECUTE_HANDLER) {
             return false; // umip
         }
 
-        return (m[5] > 0xD0);
-#else
-        return false;
-#endif
-    }
-
-
-    /**
-     * @brief Check for Offensive Security sgdt method
-     * @category Windows, x86
-     * @author Danny Quist (chamuco@gmail.com)
-     * @author Val Smith (mvalsmith@metasploit.com)
-     * @note code documentation paper in /papers/www.offensivecomputing.net_vm.pdf
-     * @implements VM::OFFSEC_SGDT
-     */
-    [[nodiscard]] static bool offsec_sgdt() {
-#if (!MSVC && WINDOWS)
-        unsigned char m[6]{};
-        __try {
-            __asm sgdt m;
-        }
-        __except (EXCEPTION_EXECUTE_HANDLER) {
-            // umip
-            return false;
+        std::memcpy(&ldt, ldtr_buf, sizeof(ldt));
+        if (ldtr_buf[0] != 0x00 && ldtr_buf[1] != 0x00) {
+            debug("SLDT: ldtr_buf signature detected");
+            return true;
         }
 
-        return (m[5] > 0xD0);
-#else
-        return false;
-#endif
-    }
-
-
-    /**
-     * @brief Check for Offensive Security sldt method
-     * @category Windows, x86
-     * @author Danny Quist (chamuco@gmail.com)
-     * @author Val Smith (mvalsmith@metasploit.com)
-     * @note code documentation paper in /papers/www.offensivecomputing.net_vm.pdf
-     * @implements VM::OFFSEC_SLDT
-     */
-    [[nodiscard]] static bool offsec_sldt() {
-#if (!WINDOWS || !x86_64)
-        return false;
-#elif (x86_32)
-        unsigned short m[6]{};
-        __try {
-            __asm sldt m;
-        }
-        __except (EXCEPTION_EXECUTE_HANDLER) {
-            // umip
-            return false;
-        }
-        return (m[0] != 0x00 && m[1] != 0x00);
-#else
-        return false;
-#endif
-    }
-
-
-    /**
-     * @brief Check for sidt method with VPC's 0xE8XXXXXX range
-     * @category Windows, x86
-     * @note Idea from Tom Liston and Ed Skoudis' paper "On the Cutting Edge: Thwarting Virtual Machine Detection"
-     * @note Paper situated at /papers/ThwartingVMDetection_Liston_Skoudis.pdf
-     * @implements VM::VPC_SIDT
-     */
-    [[nodiscard]] static bool vpc_sidt() {
-#if (!WINDOWS || !x86_64)
-        return false;
-#elif (x86_32)
-        u8	idtr[6]{};
-        u32	idt = 0;
-        __try {
-            _asm sidt idtr
-        }
-        __except (EXCEPTION_EXECUTE_HANDLER) {
-            return false; // umip
-        }
-        idt = *((unsigned long*)&idtr[2]);
-
-        if ((idt >> 24) == 0xE8) {
-            return core::add(brands::VPC);
-        }
-
-        return false;
+        return (ldt != 0xDEAD0000);
 #else
         return false;
 #endif
@@ -4506,7 +4422,7 @@ private: // START OF PRIVATE VM DETECTION TECHNIQUE DEFINITIONS
      * @category Windows
      * @implements VM::VMWARE_STR
      */
-        [[nodiscard]] static bool vmware_str() {
+    [[nodiscard]] static bool vmware_str() {
 #if (WINDOWS && x86_32)
         unsigned short tr = 0;
         __asm {
@@ -4523,7 +4439,7 @@ private: // START OF PRIVATE VM DETECTION TECHNIQUE DEFINITIONS
 
     /**
      * @brief Check for official VMware io port backdoor technique
-     * @category Windows, x86
+     * @category Windows, x86_32
      * @note Code from ScoopyNG by Tobias Klein
      * @note Technique founded by Ken Kato
      * @copyright BSD clause 2
@@ -4571,11 +4487,11 @@ private: // START OF PRIVATE VM DETECTION TECHNIQUE DEFINITIONS
 
         if (is_vm) {
             switch (b) {
-                case 1:  return core::add(brands::VMWARE_EXPRESS);
-                case 2:  return core::add(brands::VMWARE_ESX);
-                case 3:  return core::add(brands::VMWARE_GSX);
-                case 4:  return core::add(brands::VMWARE_WORKSTATION);
-                default: return core::add(brands::VMWARE);
+            case 1:  return core::add(brands::VMWARE_EXPRESS);
+            case 2:  return core::add(brands::VMWARE_ESX);
+            case 3:  return core::add(brands::VMWARE_GSX);
+            case 4:  return core::add(brands::VMWARE_WORKSTATION);
+            default: return core::add(brands::VMWARE);
             }
         }
 
@@ -4588,7 +4504,7 @@ private: // START OF PRIVATE VM DETECTION TECHNIQUE DEFINITIONS
 
     /**
      * @brief Check for VMware memory using IO port backdoor
-     * @category Windows, x86
+     * @category Windows, x86_32
      * @note Code from ScoopyNG by Tobias Klein
      * @copyright BSD clause 2
      * @implements VM::VMWARE_PORT_MEM
@@ -4633,7 +4549,7 @@ private: // START OF PRIVATE VM DETECTION TECHNIQUE DEFINITIONS
 
     /**
      * @brief Check for SMSW assembly instruction technique
-     * @category Windows, x86
+     * @category Windows, x86_32
      * @author Danny Quist from Offensive Computing
      * @implements VM::SMSW
      */
@@ -4653,7 +4569,7 @@ private: // START OF PRIVATE VM DETECTION TECHNIQUE DEFINITIONS
         return (
             (((reax >> 24) & 0xFF) == 0xCC) &&
             (((reax >> 16) & 0xFF) == 0xCC)
-        );
+            );
 #else
         return false;
 #endif
@@ -4662,7 +4578,7 @@ private: // START OF PRIVATE VM DETECTION TECHNIQUE DEFINITIONS
 
     /**
      * @brief Check for mutex strings of VM brands
-     * @category Windows, x86
+     * @category Windows
      * @note from VMDE project
      * @author hfiref0x
      * @implements VM::MUTEX
@@ -4685,12 +4601,12 @@ private: // START OF PRIVATE VM DETECTION TECHNIQUE DEFINITIONS
             }
 
             return (dwError == ERROR_ALREADY_EXISTS);
-        };
+            };
 
         if (
             supMutexExist("Sandboxie_SingleInstanceMutex_Control") ||
             supMutexExist("SBIE_BOXED_ServiceInitComplete_Mutex1")
-        ) {
+            ) {
             return core::add(brands::SANDBOXIE);
         }
 
@@ -4709,7 +4625,7 @@ private: // START OF PRIVATE VM DETECTION TECHNIQUE DEFINITIONS
 
     /**
      * @brief Check for odd CPU threads, usually a sign of modification through VM setting because 99% of CPUs have even numbers of threads
-     * @category All, x86
+     * @category x86
      * @implements VM::ODD_CPU_THREADS
      */
     [[nodiscard]] static bool odd_cpu_threads() {
@@ -4726,48 +4642,48 @@ private: // START OF PRIVATE VM DETECTION TECHNIQUE DEFINITIONS
 
         // check if the microarchitecture was made before 2006, which was around the time multi-core processors were implemented
         auto old_microarchitecture = [&steps]() -> bool {
-            constexpr std::array<std::array<u8, 3>, 32> old_archs = {{
-                // 80486
-                {{ 0x4, 0x0, 0x1 }},
-                {{ 0x4, 0x0, 0x2 }},
-                {{ 0x4, 0x0, 0x3 }},
-                {{ 0x4, 0x0, 0x4 }},
-                {{ 0x4, 0x0, 0x5 }},
-                {{ 0x4, 0x0, 0x7 }},
-                {{ 0x4, 0x0, 0x8 }},
-                {{ 0x4, 0x0, 0x9 }},
+            constexpr std::array<std::array<u8, 3>, 32> old_archs = { {
+                    // 80486
+                    {{ 0x4, 0x0, 0x1 }},
+                    {{ 0x4, 0x0, 0x2 }},
+                    {{ 0x4, 0x0, 0x3 }},
+                    {{ 0x4, 0x0, 0x4 }},
+                    {{ 0x4, 0x0, 0x5 }},
+                    {{ 0x4, 0x0, 0x7 }},
+                    {{ 0x4, 0x0, 0x8 }},
+                    {{ 0x4, 0x0, 0x9 }},
 
-                // P5
-                {{ 0x5, 0x0, 0x1 }},
-                {{ 0x5, 0x0, 0x2 }},
-                {{ 0x5, 0x0, 0x4 }},
-                {{ 0x5, 0x0, 0x7 }},
-                {{ 0x5, 0x0, 0x8 }},
+                    // P5
+                    {{ 0x5, 0x0, 0x1 }},
+                    {{ 0x5, 0x0, 0x2 }},
+                    {{ 0x5, 0x0, 0x4 }},
+                    {{ 0x5, 0x0, 0x7 }},
+                    {{ 0x5, 0x0, 0x8 }},
 
-                // P6
-                {{ 0x6, 0x0, 0x1 }},
-                {{ 0x6, 0x0, 0x3 }},
-                {{ 0x6, 0x0, 0x5 }},
-                {{ 0x6, 0x0, 0x6 }},
-                {{ 0x6, 0x0, 0x7 }},
-                {{ 0x6, 0x0, 0x8 }},
-                {{ 0x6, 0x0, 0xA }},
-                {{ 0x6, 0x0, 0xB }},
+                    // P6
+                    {{ 0x6, 0x0, 0x1 }},
+                    {{ 0x6, 0x0, 0x3 }},
+                    {{ 0x6, 0x0, 0x5 }},
+                    {{ 0x6, 0x0, 0x6 }},
+                    {{ 0x6, 0x0, 0x7 }},
+                    {{ 0x6, 0x0, 0x8 }},
+                    {{ 0x6, 0x0, 0xA }},
+                    {{ 0x6, 0x0, 0xB }},
 
-                // Netburst
-                {{ 0xF, 0x0, 0x6 }},
-                {{ 0xF, 0x0, 0x4 }},
-                {{ 0xF, 0x0, 0x3 }},
-                {{ 0xF, 0x0, 0x2 }},
-                {{ 0xF, 0x0, 0x10 }},
+                    // Netburst
+                    {{ 0xF, 0x0, 0x6 }},
+                    {{ 0xF, 0x0, 0x4 }},
+                    {{ 0xF, 0x0, 0x3 }},
+                    {{ 0xF, 0x0, 0x2 }},
+                    {{ 0xF, 0x0, 0x10 }},
 
-                {{ 0x6, 0x1, 0x5 }}, // Pentium M (Talopai)
-                {{ 0x6, 0x1, 0x6 }}, // Core (Client)
-                {{ 0x6, 0x0, 0x9 }}, // Pentium M
-                {{ 0x6, 0x0, 0xD }}, // Pentium M
-                {{ 0x6, 0x0, 0xE }}, // Modified Pentium M
-                {{ 0x6, 0x0, 0xF }}  // Core (Client)
-            }};
+                    {{ 0x6, 0x1, 0x5 }}, // Pentium M (Talopai)
+                    {{ 0x6, 0x1, 0x6 }}, // Core (Client)
+                    {{ 0x6, 0x0, 0x9 }}, // Pentium M
+                    {{ 0x6, 0x0, 0xD }}, // Pentium M
+                    {{ 0x6, 0x0, 0xE }}, // Modified Pentium M
+                    {{ 0x6, 0x0, 0xF }}  // Core (Client)
+                } };
 
             constexpr u8 FAMILY = 0;
             constexpr u8 EXTMODEL = 1;
@@ -4784,7 +4700,7 @@ private: // START OF PRIVATE VM DETECTION TECHNIQUE DEFINITIONS
             }
 
             return false;
-        };
+            };
 
         // self-explanatory
         if (!(cpu::is_intel() || cpu::is_amd())) {
@@ -4809,7 +4725,7 @@ private: // START OF PRIVATE VM DETECTION TECHNIQUE DEFINITIONS
 
     /**
      * @brief Check for Intel CPU thread count database if it matches the system's thread count
-     * @category All, x86
+     * @category x86
      * @implements VM::INTEL_THREAD_MISMATCH
      */
     [[nodiscard]] static bool intel_thread_mismatch() {
@@ -5810,7 +5726,7 @@ private: // START OF PRIVATE VM DETECTION TECHNIQUE DEFINITIONS
 
     /**
      * @brief Same as above, but for Xeon Intel CPUs
-     * @category All, x86
+     * @category x86
      * @link https://en.wikipedia.org/wiki/List_of_Intel_Core_processors
      * @implements VM::XEON_THREAD_MISMATCH
      */
@@ -5960,7 +5876,7 @@ private: // START OF PRIVATE VM DETECTION TECHNIQUE DEFINITIONS
 
         debug("XEON_THREAD_MISMATCH: thread in database = ", static_cast<u32>(threads));
 
-        return (std::thread::hardware_concurrency() != (threads < 0 ? 0 : static_cast<unsigned int>(threads)));
+        return (std::thread::hardware_concurrency() != static_cast<unsigned int>(threads));
 #endif
     }
 
@@ -6116,8 +6032,8 @@ private: // START OF PRIVATE VM DETECTION TECHNIQUE DEFINITIONS
             CM_FULL_RESOURCE_DESCRIPTOR List[1];
         } *PCM_RESOURCE_LIST, CM_RESOURCE_LIST;
         struct map_key {
-            LPCTSTR KeyPath;  
-            LPCTSTR ValueName; 
+            LPCTSTR KeyPath;
+            LPCTSTR ValueName;
         };
 
 #define VBOX_PHYS_LO 0x0000000000001000ULL
@@ -6324,9 +6240,9 @@ private: // START OF PRIVATE VM DETECTION TECHNIQUE DEFINITIONS
 
         const size_t hyphen_pos = hostname.find('-', 5);
 
-        if (hyphen_pos == std::string::npos || 
-            hyphen_pos <= 5 ||                   
-            hyphen_pos >= len - 1) {             
+        if (hyphen_pos == std::string::npos ||
+            hyphen_pos <= 5 ||
+            hyphen_pos >= len - 1) {
             return false;
         }
 
@@ -6358,7 +6274,7 @@ private: // START OF PRIVATE VM DETECTION TECHNIQUE DEFINITIONS
 
         auto cmp = [&](const char* str2) -> bool {
             return (hostname == str2);
-        };
+            };
 
         if (
             cmp("Sandbox") ||
@@ -6366,7 +6282,7 @@ private: // START OF PRIVATE VM DETECTION TECHNIQUE DEFINITIONS
             cmp("Malware") ||
             cmp("malsand") ||
             cmp("ClonePC")
-        ) {
+            ) {
             return true;
         }
 
@@ -6402,7 +6318,7 @@ private: // START OF PRIVATE VM DETECTION TECHNIQUE DEFINITIONS
             (horiz == 1024 && verti == 768) ||
             (horiz == 800 && verti == 600) ||
             (horiz == 640 && verti == 480)
-        ) {
+            ) {
             return true;
         }
 
@@ -6427,7 +6343,8 @@ private: // START OF PRIVATE VM DETECTION TECHNIQUE DEFINITIONS
 
         if (BuildCommDCBAndTimeoutsA("jhl46745fghb", &dcb, &timeouts)) {
             return true;
-        } else {
+        }
+        else {
             return false;
         }
 #endif
@@ -6446,7 +6363,7 @@ private: // START OF PRIVATE VM DETECTION TECHNIQUE DEFINITIONS
         if (
             util::exists("/mnt/windows/BstSharedFolder") ||
             util::exists("/sdcard/windows/BstSharedFolder")
-        ) {
+            ) {
             return core::add(brands::BLUESTACKS);
         }
 
@@ -6475,7 +6392,7 @@ private: // START OF PRIVATE VM DETECTION TECHNIQUE DEFINITIONS
 
         debug("CPUID_SIGNATURE: eax = ", eax);
 
-        if (eax == nanovisor) 
+        if (eax == nanovisor)
             return core::add(brands::NANOVISOR);
         else if (eax == simplevisor)
             return core::add(brands::SIMPLEVISOR);
@@ -6503,7 +6420,7 @@ private: // START OF PRIVATE VM DETECTION TECHNIQUE DEFINITIONS
             (ebx == 0x4b4d564b) &&
             (ecx == 0x564b4d56) &&
             (edx == 0x4d)
-        )) {
+            )) {
             return false;
         }
 
@@ -6513,7 +6430,7 @@ private: // START OF PRIVATE VM DETECTION TECHNIQUE DEFINITIONS
             (eax & (1 << 8)) &&
             (((eax >> 13) & 0b1111111111) == 0) &&
             ((eax >> 24) == 0)
-        ) {
+            ) {
             return core::add(brands::KVM);
         }
 
@@ -6563,19 +6480,19 @@ private: // START OF PRIVATE VM DETECTION TECHNIQUE DEFINITIONS
         if (
             util::exists(sys_vendor) &&
             util::exists(modalias)
-        ) {
+            ) {
             const std::string sys_vendor_str = util::read_file(sys_vendor);
             const std::string modalias_str = util::read_file(modalias);
 
             return (
                 util::find(sys_vendor_str, "QEMU") &&
                 util::find(modalias_str, "QEMU")
-            );
+                );
         }
 
         return false;
 #endif
-    } 
+    }
 
 
     /**
@@ -6630,9 +6547,9 @@ private: // START OF PRIVATE VM DETECTION TECHNIQUE DEFINITIONS
 
         while ((entry = readdir(dir)) != nullptr) {
             if (
-                (entry->d_name[0] == '.' && entry->d_name[1] == '\0') || 
+                (entry->d_name[0] == '.' && entry->d_name[1] == '\0') ||
                 (entry->d_name[1] == '.' && entry->d_name[2] == '\0')
-            ) {
+                ) {
                 continue;
             }
 
@@ -6658,7 +6575,7 @@ private: // START OF PRIVATE VM DETECTION TECHNIQUE DEFINITIONS
         // check if there's a few files in that directory
         return ((count != 0) && type);
 #endif
-    } 
+    }
 
 
     /**
@@ -6691,7 +6608,7 @@ private: // START OF PRIVATE VM DETECTION TECHNIQUE DEFINITIONS
 
         return false;
 #endif
-    } 
+    }
 
 
     /**
@@ -6723,12 +6640,15 @@ private: // START OF PRIVATE VM DETECTION TECHNIQUE DEFINITIONS
             if (bytes_read > 0) {
                 buffer[bytes_read] = '\0';
                 ss << buffer;
-            } else if (bytes_read == 0) {
+            }
+            else if (bytes_read == 0) {
                 usleep(100000); // Sleep for 100 milliseconds
-            } else {
+            }
+            else {
                 if (errno == EAGAIN) {
                     usleep(100000); // Sleep for 100 milliseconds
-                } else {
+                }
+                else {
                     debug("KMSG: Error reading /dev/kmsg");
                     break;
                 }
@@ -6749,7 +6669,7 @@ private: // START OF PRIVATE VM DETECTION TECHNIQUE DEFINITIONS
 
         return (util::find(content, "Hypervisor detected"));
 #endif
-    } 
+    }
 
 
     /**
@@ -6772,7 +6692,7 @@ private: // START OF PRIVATE VM DETECTION TECHNIQUE DEFINITIONS
 
         return false;
 #endif
-    } 
+    }
 
 
     /**
@@ -6826,7 +6746,7 @@ private: // START OF PRIVATE VM DETECTION TECHNIQUE DEFINITIONS
 
         return false;
 #endif
-    } 
+    }
 
 
     /**
@@ -6845,7 +6765,7 @@ private: // START OF PRIVATE VM DETECTION TECHNIQUE DEFINITIONS
 
         return (util::exists("/proc/device-tree/hypervisor/compatible"));
 #endif
-    } 
+    }
 
 
     /**
@@ -6864,7 +6784,7 @@ private: // START OF PRIVATE VM DETECTION TECHNIQUE DEFINITIONS
         cat: /sys/class/dmi/id/product_uuid: Permission denied
         */
 
-        constexpr std::array<const char*, 7> dmi_array {
+        constexpr std::array<const char*, 7> dmi_array{
             "/sys/class/dmi/id/bios_vendor",
             "/sys/class/dmi/id/board_name",
             "/sys/class/dmi/id/board_vendor",
@@ -6874,7 +6794,7 @@ private: // START OF PRIVATE VM DETECTION TECHNIQUE DEFINITIONS
             "/sys/class/dmi/id/sys_vendor"
         };
 
-        constexpr std::array<std::pair<const char*, const char*>, 15> vm_table {{
+        constexpr std::array<std::pair<const char*, const char*>, 15> vm_table{ {
             { "kvm", brands::KVM },
             { "openstack", brands::OPENSTACK },
             { "kubevirt", brands::KUBEVIRT },
@@ -6891,9 +6811,9 @@ private: // START OF PRIVATE VM DETECTION TECHNIQUE DEFINITIONS
             { "hyper-v", brands::HYPERV },
             { "apple virtualization", brands::APPLE_VZ },
             { "google compute engine", brands::GCE }
-        }};
+        } };
 
-        auto to_lower = [](std::string &str) {
+        auto to_lower = [](std::string& str) {
             for (auto& c : str) {
                 if (c == ' ') {
                     continue;
@@ -6901,9 +6821,9 @@ private: // START OF PRIVATE VM DETECTION TECHNIQUE DEFINITIONS
 
                 c = static_cast<char>(tolower(c));
             }
-        };
+            };
 
-        for (const auto &vm_string : vm_table) {
+        for (const auto& vm_string : vm_table) {
             for (const auto file : dmi_array) {
                 if (!util::exists(file)) {
                     continue;
@@ -6919,7 +6839,8 @@ private: // START OF PRIVATE VM DETECTION TECHNIQUE DEFINITIONS
                         if (smbios_vm_bit()) {
                             return core::add(brands::AWS_NITRO);
                         }
-                    } else {
+                    }
+                    else {
                         return core::add(vm_string.second);
                     }
                 }
@@ -6928,7 +6849,7 @@ private: // START OF PRIVATE VM DETECTION TECHNIQUE DEFINITIONS
 
         return false;
 #endif
-    } 
+    }
 
 
     /**
@@ -6962,7 +6883,7 @@ private: // START OF PRIVATE VM DETECTION TECHNIQUE DEFINITIONS
 
         return (content.at(19) & (1 << 4));
 #endif
-    } 
+    }
 
 
     /**
@@ -7000,21 +6921,21 @@ private: // START OF PRIVATE VM DETECTION TECHNIQUE DEFINITIONS
         if (
             util::exists(osrelease) &&
             util::exists(version)
-        ) {
+            ) {
             const std::string osrelease_content = util::read_file(osrelease);
             const std::string version_content = util::read_file(version);
 
             if (
                 (util::find(osrelease_content, "WSL") || util::find(osrelease_content, "Microsoft")) &&
                 (util::find(version, "WSL") || util::find(version, "Microsoft"))
-            ) {
+                ) {
                 return core::add(brands::WSL);
             }
         }
 
         return false;
 #endif
-    } 
+    }
 
 
     /**
@@ -7084,7 +7005,7 @@ private: // START OF PRIVATE VM DETECTION TECHNIQUE DEFINITIONS
 
         if (ntQuerySystemInformation == nullptr || ntAllocateVirtualMemory == nullptr || ntFreeVirtualMemory == nullptr)
             return false;
-        
+
         ULONG ulSize = 0;
         NTSTATUS status = ntQuerySystemInformation(SystemModuleInformation, nullptr, 0, &ulSize);
         if (status != STATUS_INFO_LENGTH_MISMATCH) return false;
@@ -7125,41 +7046,6 @@ private: // START OF PRIVATE VM DETECTION TECHNIQUE DEFINITIONS
         }
 
         ntFreeVirtualMemory(hProcess, &allocatedMemory, &regionSize, MEM_RELEASE);
-        return false;
-#endif
-    }
-
-
-    /**
-     * @brief Check for unknown IDT base address
-     * @category Windows
-     * @implements VM::VM_SIDT
-     */
-    [[nodiscard]] static bool vm_sidt() {
-#if (!WINDOWS || !x86) 
-        return false;
-#else    
-#pragma pack(push, 1)
-        struct IDTR { uint16_t limit;  uint64_t base; };
-#pragma pack(pop)
-
-        IDTR idtr;
-        __try {
-            #if (CLANG || GCC)
-                __asm__ volatile("sidt %0" : "=m"(idtr));
-            #else
-                 __sidt(&idtr);
-            #endif
-        }
-        __except (EXCEPTION_EXECUTE_HANDLER) {
-            return false; // umip
-        }
-        u64 idt_base = idtr.base;
-
-        if ((idt_base >> 24) == 0xff) {
-            return true;
-        }
-
         return false;
 #endif
     }
@@ -7287,7 +7173,7 @@ private: // START OF PRIVATE VM DETECTION TECHNIQUE DEFINITIONS
     /**
      * @brief Check for physical connection ports
      * @category Windows
-     * @note original idea of using physical ports to detect VMs was suggested by @unusual-aspect (https://github.com/unusual-aspect). 
+     * @note original idea of using physical ports to detect VMs was suggested by @unusual-aspect (https://github.com/unusual-aspect).
      *       This technique is known to false flag on devices like Surface Pro.
      * @implements VM::PORT_CONNECTORS
      */
@@ -7326,50 +7212,59 @@ private: // START OF PRIVATE VM DETECTION TECHNIQUE DEFINITIONS
 #if (!WINDOWS)
         return false;
 #else
+
+#if (CPP >= 17)
         struct VMGpuInfo {
-            const wchar_t* name;  
+            std::wstring_view name;
             const char* brand;
-            size_t length;       
         };
 
-        constexpr std::array<VMGpuInfo, 10> vm_gpu_names = { {
-            { L"VMware SVGA 3D",                   brands::VMWARE,   14 },
-            { L"VirtualBox Graphics Adapter",      brands::VBOX,     27 },
-            { L"QXL GPU",                          brands::KVM,      7 },
-            { L"VirGL 3D",                         brands::QEMU,     8 },
-            { L"Microsoft Hyper-V Video",          brands::HYPERV,   23 },
-            { L"Parallels Display Adapter (WDDM)", brands::PARALLELS, 32 },
-            { L"Bochs Graphics Adapter",           brands::BOCHS,    22 },
-            { L"Bochs Graphics Adapter",           brands::BOCHS,    22 },
-            { L"Virtual Display Driver",           brands::NULL_BRAND,  22 },
-            { L"IddSampleDriver Device",           brands::NULL_BRAND,  22 }
+        static constexpr std::array<VMGpuInfo, 8> vm_gpu_names = { {
+            { L"VMware SVGA 3D",                   brands::VMWARE    },
+            { L"VirtualBox Graphics Adapter",      brands::VBOX      },
+            { L"QXL GPU",                          brands::KVM       },
+            { L"VirGL 3D",                         brands::QEMU      },
+            { L"Microsoft Hyper-V Video",          brands::HYPERV    },
+            { L"Parallels Display Adapter (WDDM)", brands::PARALLELS },
+            { L"Bochs Graphics Adapter",           brands::BOCHS     },
+            { L"IddSampleDriver Device",           brands::NULL_BRAND}
         } };
+#else
+        struct VMGpuInfo {
+            const wchar_t* name;
+            const char* brand;
+        };
+
+        static const VMGpuInfo vm_gpu_names[8] = {
+            { L"VMware SVGA 3D",                   brands::VMWARE    },
+            { L"VirtualBox Graphics Adapter",      brands::VBOX      },
+            { L"QXL GPU",                          brands::KVM       },
+            { L"VirGL 3D",                         brands::QEMU      },
+            { L"Microsoft Hyper-V Video",          brands::HYPERV    },
+            { L"Parallels Display Adapter (WDDM)", brands::PARALLELS },
+            { L"Bochs Graphics Adapter",           brands::BOCHS     },
+            { L"IddSampleDriver Device",           brands::NULL_BRAND}
+        };
+#endif
 
         DISPLAY_DEVICEW dd{};
-        dd.cb = sizeof(DISPLAY_DEVICEW);
-        DWORD deviceNum = 0;
+        dd.cb = sizeof(dd);
 
-        while (EnumDisplayDevicesW(nullptr, deviceNum, &dd, 0)) {
-            const wchar_t* deviceStr = dd.DeviceString;
-            const size_t deviceStrLen = wcslen(deviceStr);
-
-#if CPP >= 17
-            for (const auto& [name, brand, len] : vm_gpu_names) {
-#else
-            for (const auto& entry : vm_gpu_names) {
-                const wchar_t* name = entry.name;
-                const char* brand = entry.brand;
-                const size_t len = entry.length;
-#endif
-                if (deviceStrLen == len && wcscmp(deviceStr, name) == 0) {   
-                    char* castedName = (char*)calloc(len, sizeof(char));
-                    size_t ret = wcstombs(castedName, name, len);
-                    castedName[ret] = '\0';
-                    return core::add(brand);
+        for (DWORD deviceNum = 0; EnumDisplayDevicesW(nullptr, deviceNum, &dd, 0); ++deviceNum) {
+#if (CPP >= 17)
+            std::wstring_view devStr{ dd.DeviceString };
+            for (auto const& info : vm_gpu_names) {
+                if (devStr == info.name) {
+                    return core::add(info.brand);
                 }
             }
-
-            ++deviceNum;
+#else
+            for (int i = 0; i < 8; ++i) {
+                if (wcscmp(dd.DeviceString, vm_gpu_names[i].name) == 0) {
+                    return core::add(vm_gpu_names[i].brand);
+                }
+            }
+#endif
         }
 
         return false;
@@ -7387,10 +7282,6 @@ private: // START OF PRIVATE VM DETECTION TECHNIQUE DEFINITIONS
 #if (!WINDOWS)
         return false;
 #else
-        if (!util::is_admin()) {
-            return false;
-        }
-
         IDirect3D9* pD3D = Direct3DCreate9(D3D_SDK_VERSION);
         if (!pD3D) {
             debug("GPU_CAPABILITIES: Direct3DCreate9 failed");
@@ -7399,48 +7290,14 @@ private: // START OF PRIVATE VM DETECTION TECHNIQUE DEFINITIONS
 
         D3DADAPTER_IDENTIFIER9 adapterId;
         if (SUCCEEDED(pD3D->GetAdapterIdentifier(D3DADAPTER_DEFAULT, 0, &adapterId))) {
-            if (adapterId.VendorId == 0x15AD) {   
+            if (adapterId.VendorId == 0x15AD) {
                 pD3D->Release();
                 return core::add(brands::VMWARE);
             }
-            else if (adapterId.VendorId == 0x80EE) {   
+            else if (adapterId.VendorId == 0x80EE) {
                 pD3D->Release();
                 return core::add(brands::VBOX);
             }
-        }
-
-        D3DCAPS9 caps;
-        HRESULT hr = pD3D->GetDeviceCaps(D3DADAPTER_DEFAULT, D3DDEVTYPE_HAL, &caps);
-        const int maxRetries = 3;
-        for (int attempt = 0; FAILED(hr) && (attempt < maxRetries); ++attempt) {
-            SleepEx(500, FALSE);  
-            hr = pD3D->GetDeviceCaps(D3DADAPTER_DEFAULT, D3DDEVTYPE_HAL, &caps);
-        }
-        if (FAILED(hr)) {
-            debug("GPU_CAPABILITIES: GetDeviceCaps failure");
-            pD3D->Release();
-            return false;
-        }
-
-        // Pixel Shader version 2.0
-        if (caps.PixelShaderVersion < D3DPS_VERSION(2, 0)) {
-            debug("GPU_CAPABILITIES: Insufficient Pixel Shader version");
-            pD3D->Release();
-            return true;
-        }
-
-        // hardware transform and lighting capability
-        if (!(caps.DevCaps & D3DDEVCAPS_HWTRANSFORMANDLIGHT)) {
-            debug("GPU_CAPABILITIES: Missing hardware T&L support");
-            pD3D->Release();
-            return true;
-        }
-
-        // simultaneous render targets
-        if (caps.NumSimultaneousRTs < 2) {
-            debug("GPU_CAPABILITIES: Insufficient simultaneous render targets");
-            pD3D->Release();
-            return true;
         }
 
         pD3D->Release();
@@ -7451,12 +7308,14 @@ private: // START OF PRIVATE VM DETECTION TECHNIQUE DEFINITIONS
             return true;
         }
 
-        IDXGIAdapter* pAdapter = nullptr;
         // Enumerate only the primary adapter so as not to mistakenly flag machines without a dedicated GPU, like Microsoft Basic Render Driver (vid 0x1414)
-        if (pFactory->EnumAdapters(0, &pAdapter) != DXGI_ERROR_NOT_FOUND) {
+        IDXGIAdapter* pAdapter = nullptr;
+        HRESULT hrEnum = pFactory->EnumAdapters(0, &pAdapter);
+        if (SUCCEEDED(hrEnum)) {
             DXGI_ADAPTER_DESC adapterDesc;
             if (SUCCEEDED(pAdapter->GetDesc(&adapterDesc))) {
-                if (adapterDesc.DedicatedVideoMemory < (1024ULL * 1024ULL * 1024ULL)) {
+                const UINT64 minVidMem = 1024ULL * 1024ULL * 1024ULL;
+                if (adapterDesc.DedicatedVideoMemory < minVidMem) {
                     debug("GPU_CAPABILITIES: Video memory below threshold");
                     pAdapter->Release();
                     pFactory->Release();
@@ -7465,11 +7324,12 @@ private: // START OF PRIVATE VM DETECTION TECHNIQUE DEFINITIONS
             }
             pAdapter->Release();
         }
-        pFactory->Release();
 
+        pFactory->Release();
         return false;
 #endif
     }
+
 
 
     /**
@@ -7495,7 +7355,7 @@ private: // START OF PRIVATE VM DETECTION TECHNIQUE DEFINITIONS
             (handle2 != INVALID_HANDLE_VALUE) ||
             (handle3 != INVALID_HANDLE_VALUE) ||
             (handle4 != INVALID_HANDLE_VALUE)
-           ) {
+            ) {
             vbox = true;
         }
 
@@ -7525,7 +7385,7 @@ private: // START OF PRIVATE VM DETECTION TECHNIQUE DEFINITIONS
 
         return false;
 #endif
-    }    
+    }
 
 
     /**
@@ -7606,7 +7466,7 @@ private: // START OF PRIVATE VM DETECTION TECHNIQUE DEFINITIONS
         SP_DEVICE_INTERFACE_DATA deviceInterfaceData{};
         deviceInterfaceData.cbSize = sizeof(SP_DEVICE_INTERFACE_DATA);
 
-        bool exists = SetupDiEnumDeviceInterfaces(hDevInfo, nullptr, &GUID_DEVCLASS_THERMALZONE, 0, &deviceInterfaceData);
+        const bool exists = SetupDiEnumDeviceInterfaces(hDevInfo, nullptr, &GUID_DEVCLASS_THERMALZONE, 0, &deviceInterfaceData);
         SetupDiDestroyDeviceInfoList(hDevInfo);
 
         return !exists;
@@ -7620,11 +7480,11 @@ private: // START OF PRIVATE VM DETECTION TECHNIQUE DEFINITIONS
      * @author Requiem (https://github.com/NotRequiem)
      * @implements VM::TIMER
      */
-#if defined(MSVC)
+#if (MSVC)
 #pragma optimize("", off)
-#elif defined(CLANG)
+#elif (CLANG)
 #pragma clang optimize off
-#elif defined(GCC)
+#elif (GCC)
 #pragma GCC push_options
 #pragma GCC optimize("O0")
 #endif
@@ -7645,7 +7505,7 @@ private: // START OF PRIVATE VM DETECTION TECHNIQUE DEFINITIONS
         constexpr u8 requiredClassicSpikes = rdtscIterations / 2; // At least 50% of iterations must spike
 
         constexpr u16 spammerIterations = 1000;           // Iterations for the multi-CPU/spammer check
-        constexpr u16 spammerAvgThreshold = 1500;         // Average cycle threshold for the spammer check
+        constexpr u16 spammerAvgThreshold = 5000;         // Average cycle threshold for the spammer check
 
 #if (WINDOWS)
         constexpr u16 qpcRatioThreshold = 70;           // QPC ratio threshold
@@ -7670,7 +7530,7 @@ private: // START OF PRIVATE VM DETECTION TECHNIQUE DEFINITIONS
             newParam.sched_priority = sched_get_priority_max(SCHED_FIFO);
 
             if (sched_setscheduler(0, SCHED_FIFO, &newParam) == -1) {
-                hasSchedPriority = false;  
+                hasSchedPriority = false;
             }
         }
 #endif
@@ -7746,7 +7606,7 @@ private: // START OF PRIVATE VM DETECTION TECHNIQUE DEFINITIONS
             if (flushBuffer) {
                 for (size_t j = offsetStart; j < offsetEnd; j += 64) {
                     flushBuffer[j] = static_cast<char>(j);
-#if defined(x86) && (defined(GCC) || defined(CLANG) || defined(MSVC))
+#if (x86) && (GCC || CLANG || MSVC)
                     COMPILER_BARRIER();
                     // _mm_clflushopt not available on some systems
                     _mm_clflush(reinterpret_cast<const void*>(&flushBuffer[j]));
@@ -7764,9 +7624,9 @@ private: // START OF PRIVATE VM DETECTION TECHNIQUE DEFINITIONS
 #endif
 
 #ifdef __VMAWARE_DEBUG__
-        const double averageCycles = static_cast<double>(totalCycles) / classicIterations;
+        const double averageCycles = static_cast<double>(totalCycles) / rdtscIterations;
         debug("TIMER: RDTSC check - Average cycles: ", averageCycles,
-            " (Threshold per sample: ", classicThreshold,
+            " (Threshold per sample: ", rdtscThreshold,
             ") - Spike count: ", spikeCount);
 #endif
 
@@ -7779,31 +7639,56 @@ private: // START OF PRIVATE VM DETECTION TECHNIQUE DEFINITIONS
         // --- 2. Multi-CPU Spammer Check ---
         // rdtsc+cpuid+rdtsc on CPU1 while CPU2 spams cpuid. This detection tries to detect invariant TSC to flag hypervisors that share the same timer across multiple vCPUs
         std::atomic<bool> stopSpammer{ false };
-        std::thread spammer([&stopSpammer] {
+        bool spammerThreadStarted = false;
+        bool singleCore = false;
+
+        std::thread spammer;
+
+        try {
+            spammer = std::thread([&stopSpammer, &singleCore] {
+                try {
 #if (WINDOWS)
-            SetThreadAffinityMask(GetCurrentThread(), 2);
+                    if (!SetThreadAffinityMask(GetCurrentThread(), 2)) {
+                        singleCore = true;
+                        return;
+                    }
 #elif (LINUX)
-            cpu_set_t cpuset;
-            CPU_ZERO(&cpuset);
-            CPU_SET(1, &cpuset);  // core 1 (0-indexed)
-            pthread_setaffinity_np(pthread_self(), sizeof(cpu_set_t), &cpuset);
+                    cpu_set_t cpuset;
+                    CPU_ZERO(&cpuset);
+                    CPU_SET(1, &cpuset); // core 1 (0-indexed)
+                    if (pthread_setaffinity_np(pthread_self(), sizeof(cpu_set_t), &cpuset) != 0) {
+                        singleCore = true;
+                        return;
+                    }
 #elif (APPLE)
-            thread_affinity_policy_data_t policy = { 1 };
-            thread_policy_set(pthread_mach_thread_np(pthread_self()),
-                THREAD_AFFINITY_POLICY,
-                (thread_policy_t)&policy, 1);
+                    thread_affinity_policy_data_t policy = { 1 };
+                    if (thread_policy_set(pthread_mach_thread_np(pthread_self()),
+                        THREAD_AFFINITY_POLICY,
+                        (thread_policy_t)&policy, 1) != KERN_SUCCESS) {
+                        singleCore = true;
+                        return;
+                    }
 #endif
-            // hypervisor trap pressure
-            while (!stopSpammer.load()) {
+                    // hypervisor trap pressure
+                    while (!stopSpammer.load()) {
 #if (WINDOWS)
-                int cpu_info[4];
-                __cpuid(cpu_info, 0);
+                        int cpu_info[4];
+                        __cpuid(cpu_info, 0); // no need for memory barrier as cpuid is a full memory barrier on itself
 #elif (LINUX || APPLE)
-                u32 eax = 0, ebx = 0, ecx = 0, edx = 0;
-                __cpuid(0, eax, ebx, ecx, edx);
+                        u32 eax = 0, ebx = 0, ecx = 0, edx = 0;
+                        __cpuid(0, eax, ebx, ecx, edx);
 #endif
-            }
-            });
+                    }
+                }
+                catch (...) {
+                    singleCore = true;
+                }
+                });
+            spammerThreadStarted = true;
+        }
+        catch (...) {
+
+        }
 
         // --- 3a. Pin Measurement Thread for Consistent Timing ---
 #if (WINDOWS)
@@ -7818,7 +7703,6 @@ private: // START OF PRIVATE VM DETECTION TECHNIQUE DEFINITIONS
         CPU_SET(0, &newCpuSet);  // core 0 for consistent timing
         pthread_setaffinity_np(pthread_self(), sizeof(cpu_set_t), &newCpuSet);
 #elif (APPLE)
-        // restoration is not supported on Apple
         thread_affinity_policy_data_t policy = { 1 };
         thread_policy_set(pthread_mach_thread_np(pthread_self()),
             THREAD_AFFINITY_POLICY,
@@ -7839,9 +7723,13 @@ private: // START OF PRIVATE VM DETECTION TECHNIQUE DEFINITIONS
             u64 end = __rdtsc();
             measurement += (end - start);
         }
-        stopSpammer.store(true);
-        spammer.join();
 
+        stopSpammer.store(true);
+        if (spammerThreadStarted) {
+            spammer.join();
+        }
+
+        // Restore affinity
 #if (WINDOWS)
         SetThreadAffinityMask(GetCurrentThread(), oldAffinityMask);
 #elif (LINUX)
@@ -7853,14 +7741,13 @@ private: // START OF PRIVATE VM DETECTION TECHNIQUE DEFINITIONS
         debug("TIMER: Spammer check - Average cycles: ", (measurement / spammerIterations),
             " (Threshold: ", spammerAvgThreshold, ")");
 #endif
-
         if (spammerDetected) {
             restoreThreadPriority();
             return true;
         }
 
 #if (WINDOWS)
-        // --- 4.  QPC Check ---
+        // --- 4. QPC Check ---
         // Compare trapping vs non-trapping instruction timing
         LARGE_INTEGER startQPC, endQPC;
         QueryPerformanceCounter(&startQPC);
@@ -7887,7 +7774,7 @@ private: // START OF PRIVATE VM DETECTION TECHNIQUE DEFINITIONS
         }
 
         QueryPerformanceCounter(&endQPC);
-        LONGLONG dummyTime = endQPC.QuadPart - startQPC.QuadPart;
+        const LONGLONG dummyTime = endQPC.QuadPart - startQPC.QuadPart;
 
         const bool qpcCheck = (dummyTime != 0) && ((cpuIdTime / dummyTime) > qpcRatioThreshold);
 #ifdef __VMAWARE_DEBUG__
@@ -7897,169 +7784,182 @@ private: // START OF PRIVATE VM DETECTION TECHNIQUE DEFINITIONS
             " (Threshold: ", qpcRatioThreshold,
             ')');
 #endif
+        restoreThreadPriority();
 
         if (qpcCheck) {
-            restoreThreadPriority();
             return true;
         }
+#endif
+        bool tscSyncDetected = false;
 
-        // --- 5. TSC Synchronization Check Across Cores ---
-        // Try reading the invariant TSC on two different cores to attempt to detect vCPU timers being shared
-        const bool tscSyncDetected = [&]() noexcept -> bool {
-            int tscIssueCount = 0;
-            u64 tscCore1 = 0, tscCore2 = 0;
-            for (int i = 0; i < tscIterations; i++) {
-                unsigned int aux = 0;
-
-                try {
 #if (WINDOWS)
-                    DWORD_PTR oldAffinity = SetThreadAffinityMask(GetCurrentThread(), 1);
-                    tscCore1 = __rdtscp(&aux);
-                    SetThreadAffinityMask(GetCurrentThread(), 2);
-                    tscCore2 = __rdtscp(&aux);
-                    SetThreadAffinityMask(GetCurrentThread(), oldAffinity);
+        const DWORD_PTR oldTscAffinity = SetThreadAffinityMask(GetCurrentThread(), static_cast<DWORD_PTR>(~0));
 #elif (LINUX)
-                    cpu_set_t origSet;
-                    pthread_getaffinity_np(pthread_self(), sizeof(cpu_set_t), &origSet);
-
-                    // Core 0
-                    cpu_set_t set;
-                    CPU_ZERO(&set);
-                    CPU_SET(0, &set);
-                    pthread_setaffinity_np(pthread_self(), sizeof(cpu_set_t), &set);
-                    tscCore1 = __rdtscp(&aux);
-
-                    // Core 1
-                    CPU_ZERO(&set);
-                    CPU_SET(1, &set);
-                    pthread_setaffinity_np(pthread_self(), sizeof(cpu_set_t), &set);
-                    tscCore2 = __rdtscp(&aux);
-
-                    pthread_setaffinity_np(pthread_self(), sizeof(cpu_set_t), &origSet);
+        cpu_set_t oldTscSet;
+        CPU_ZERO(&oldTscSet);
+        pthread_getaffinity_np(pthread_self(), sizeof(cpu_set_t), &oldTscSet);
 #endif
-                }
-                catch (...) {
-                    tscIssueCount++;
-                    continue;
+
+
+        if (!singleCore) {
+            // --- 5. TSC Synchronization Check Across Cores ---
+            // Try reading the invariant TSC on two different cores to attempt to detect vCPU timers being shared
+            tscSyncDetected = [&]() noexcept -> bool {
+                int tscIssueCount = 0;
+                u64 tscCore1 = 0, tscCore2 = 0;
+
+                for (int i = 0; i < tscIterations; i++) {
+                    unsigned int aux = 0;
+
+                    try {
+#if (WINDOWS)
+                        SetThreadAffinityMask(GetCurrentThread(), 1);
+                        tscCore1 = __rdtscp(&aux);
+                        SetThreadAffinityMask(GetCurrentThread(), 2);
+                        tscCore2 = __rdtscp(&aux);
+#elif (LINUX)
+                        // Core 0
+                        cpu_set_t set;
+                        CPU_ZERO(&set);
+                        CPU_SET(0, &set);
+                        pthread_setaffinity_np(pthread_self(), sizeof(cpu_set_t), &set);
+                        tscCore1 = __rdtscp(&aux);
+
+                        // Core 1
+                        CPU_ZERO(&set);
+                        CPU_SET(1, &set);
+                        pthread_setaffinity_np(pthread_self(), sizeof(cpu_set_t), &set);
+                        tscCore2 = __rdtscp(&aux);
+#endif
+                    }
+                    catch (...) {
+                        tscIssueCount++; // __rdtscp should be supported on most systems
+                        continue;
+                    }
+
+                    // hypervisors often have nearly identical TSCs across vCPUs
+                    const u64 diff = (tscCore2 > tscCore1)
+                        ? (tscCore2 - tscCore1)
+                        : (tscCore1 - tscCore2);
+
+                    if (diff < tscSyncDiffThreshold) {
+                        tscIssueCount++;
+                    }
                 }
 
-                // hypervisors often have nearly identical TSCs across vCPUs
-                const u64 diff = (tscCore2 > tscCore1)
-                    ? (tscCore2 - tscCore1)
-                    : (tscCore1 - tscCore2);
-
-                if (diff < tscSyncDiffThreshold) { 
-                    tscIssueCount++;
-                }
-            }
 #ifdef __VMAWARE_DEBUG__
-            debug("TIMER: TSC sync check",
-                " - Core1: ", tscCore1,
-                " Core2: ", tscCore2,
-                " Delta: ", tscCore2 - tscCore1,
-                " (Threshold: <", tscSyncDiffThreshold,
-                ')');
+                debug("TIMER: TSC sync check",
+                    " - Core1: ", tscCore1,
+                    " Core2: ", tscCore2,
+                    " Delta: ", tscCore2 - tscCore1,
+                    " (Threshold: <", tscSyncDiffThreshold,
+                    ')');
 #endif
-            return (tscIssueCount >= tscIterations / 2);
-            }();
+
+                return (tscIssueCount >= tscIterations / 2);
+                }();
+        }
+
+#if (WINDOWS)
+        SetThreadAffinityMask(GetCurrentThread(), oldTscAffinity);
+#elif (LINUX)
+        pthread_setaffinity_np(pthread_self(), sizeof(cpu_set_t), &oldTscSet);
+#endif
 
         if (tscSyncDetected) {
-            restoreThreadPriority();
             return true;
         }
-#endif // WINDOWS
 
-        restoreThreadPriority();
         return false;
 #endif
     }
-#if defined(MSVC)
-    #pragma optimize("", on)
-#elif defined(CLANG)
-    #pragma clang optimize on
-#elif defined(GCC)
-    #pragma GCC pop_options
+#if (MSVC)
+#pragma optimize("", on)
+#elif (CLANG)
+#pragma clang optimize on
+#elif (GCC)
+#pragma GCC pop_options
 #endif
 
 
-	/**
-	 * @brief Check for existence of qemu_fw_cfg directories within sys/module and /sys/firmware
-	 * @category Linux
+    /**
+     * @brief Check for existence of qemu_fw_cfg directories within sys/module and /sys/firmware
+     * @category Linux
      * @implements VM::SYS_QEMU
-	 */
-	[[nodiscard]] static bool sys_qemu_dir() {
+     */
+    [[nodiscard]] static bool sys_qemu_dir() {
 #if (!LINUX)
-	    return false;
+        return false;
 #else
-	    const std::string module_path = "/sys/module/qemu_fw_cfg/";
-	    const std::string firmware_path = "/sys/firmware/qemu_fw_cfg/";
-	
-    #if (CPP >= 17)
+        const std::string module_path = "/sys/module/qemu_fw_cfg/";
+        const std::string firmware_path = "/sys/firmware/qemu_fw_cfg/";
+
+#if (CPP >= 17)
         namespace fs = std::filesystem;
 
-	    return (
-	        fs::is_directory(module_path) && 
-	        fs::is_directory(firmware_path) &&
-	        fs::exists(module_path) &&
-	        fs::exists(firmware_path)
-	    );
-    #else
-
-    	return (
-	        util::is_directory(module_path.c_str()) && 
-	        util::is_directory(firmware_path.c_str()) &&
-	        util::exists(module_path.c_str()) &&
-	        util::exists(firmware_path.c_str())
-	    );
-    #endif
-#endif
-	}
-
-
-	/**
-	 * @brief Check for QEMU string instances with lshw command
-	 * @category Linux
-     * @implements VM::LSHW_QEMU
-	 */
-	[[nodiscard]] static bool lshw_qemu() {
-#if (!LINUX)
-	    return false;
+        return (
+            fs::is_directory(module_path) &&
+            fs::is_directory(firmware_path) &&
+            fs::exists(module_path) &&
+            fs::exists(firmware_path)
+            );
 #else
-	    if (!(
-            (util::exists("/usr/bin/lshw")) || 
+
+        return (
+            util::is_directory(module_path.c_str()) &&
+            util::is_directory(firmware_path.c_str()) &&
+            util::exists(module_path.c_str()) &&
+            util::exists(firmware_path.c_str())
+            );
+#endif
+#endif
+    }
+
+
+    /**
+     * @brief Check for QEMU string instances with lshw command
+     * @category Linux
+     * @implements VM::LSHW_QEMU
+     */
+    [[nodiscard]] static bool lshw_qemu() {
+#if (!LINUX)
+        return false;
+#else
+        if (!(
+            (util::exists("/usr/bin/lshw")) ||
             (util::exists("/bin/lshw")) ||
             (util::exists("/usr/sbin/lshw"))
-        )) {
-	        debug("LSHW_QEMU: ", "binary doesn't exist");
-	        return false;
-	    }
+            )) {
+            debug("LSHW_QEMU: ", "binary doesn't exist");
+            return false;
+        }
 
-	    const std::unique_ptr<std::string> result = util::sys_result("lshw 2>&1");
-	
-	    if (result == nullptr) {
-	        debug("LSHW_QEMU: ", "invalid stdout output from lshw");
-	        return false;
-	    }
-	
-	    const std::string full_command = *result;
-	
-	    u8 score = 0;
+        const std::unique_ptr<std::string> result = util::sys_result("lshw 2>&1");
+
+        if (result == nullptr) {
+            debug("LSHW_QEMU: ", "invalid stdout output from lshw");
+            return false;
+        }
+
+        const std::string full_command = *result;
+
+        u8 score = 0;
 
         auto qemu_finder = [&](const char* str) -> void {
-            if (util::find(full_command, str)) { 
+            if (util::find(full_command, str)) {
                 debug("LSHW_QEMU: found ", str);
-                score++; 
+                score++;
             }
-        };
-	
-	    qemu_finder("QEMU PCIe Root port");
-	    qemu_finder("QEMU XHCI Host Controller");
-	    qemu_finder("QEMU DVD-ROM");
-	    qemu_finder("QEMU QEMU USB Tablet");
-	
-	    return (score >= 3); // if one of the strings above were detected 3 times, flag as VM
+            };
+
+        qemu_finder("QEMU PCIe Root port");
+        qemu_finder("QEMU XHCI Host Controller");
+        qemu_finder("QEMU DVD-ROM");
+        qemu_finder("QEMU QEMU USB Tablet");
+
+        return (score >= 3); // if one of the strings above were detected 3 times, flag as VM
 #endif
-	}
+    }
 
 
     /**
@@ -8075,7 +7975,7 @@ private: // START OF PRIVATE VM DETECTION TECHNIQUE DEFINITIONS
         if (!cpu::is_leaf_supported(0x40000005)) {
             return false;
         }
-        
+
         struct Registers {
             int eax = 0;
             int ebx = 0;
@@ -8466,38 +8366,38 @@ private: // START OF PRIVATE VM DETECTION TECHNIQUE DEFINITIONS
     }
 
 
-	/**
-	 * @brief Check for AMD-SEV MSR running on the system
-	 * @category x86, Linux, MacOS
-	 * @note idea from virt-what
+    /**
+     * @brief Check for AMD-SEV MSR running on the system
+     * @category x86, Linux, MacOS
+     * @note idea from virt-what
      * @implements VM::AMD_SEV
-	 */
-	[[nodiscard]] static bool amd_sev() {
+     */
+    [[nodiscard]] static bool amd_sev() {
 #if (x86 && (LINUX || APPLE))
-	    if (!cpu::is_amd()) {
-	        return false;
-	    }
-	    
-	    if (!util::is_admin()) {
-	        return false;
-	    }
-	
-	    constexpr u32 encrypted_memory_capability = 0x8000001f;
-	    constexpr u32 msr_index = 0xc0010131;	  
-        
-	    if (!cpu::is_leaf_supported(encrypted_memory_capability)) {
-	        return false;
-	    }
-	    
-	    u32 eax, unused = 0;
-	    cpu::cpuid(eax, unused, unused, unused, encrypted_memory_capability);
-	      
-	    if (!(eax & (1 << 1))) {
-	        return false;
-	    }       
-	
-	    u64 result = 0;
-	  
+        if (!cpu::is_amd()) {
+            return false;
+        }
+
+        if (!util::is_admin()) {
+            return false;
+        }
+
+        constexpr u32 encrypted_memory_capability = 0x8000001f;
+        constexpr u32 msr_index = 0xc0010131;
+
+        if (!cpu::is_leaf_supported(encrypted_memory_capability)) {
+            return false;
+        }
+
+        u32 eax, unused = 0;
+        cpu::cpuid(eax, unused, unused, unused, encrypted_memory_capability);
+
+        if (!(eax & (1 << 1))) {
+            return false;
+        }
+
+        u64 result = 0;
+
         const std::string msr_device = "/dev/cpu/0/msr";
         std::ifstream msr_file(msr_device, std::ios::binary);
 
@@ -8516,24 +8416,24 @@ private: // START OF PRIVATE VM DETECTION TECHNIQUE DEFINITIONS
 
         if (result & (static_cast<unsigned long long>(1) << 2)) { return core::add(brands::AMD_SEV_SNP); }
         else if (result & (static_cast<unsigned long long>(1) << 1)) { return core::add(brands::AMD_SEV_ES); }
-	    else if (result & 1) { return core::add(brands::AMD_SEV); }
-	
-	    return false;
+        else if (result & 1) { return core::add(brands::AMD_SEV); }
+
+        return false;
 #else
         return false;
 #endif
-	}
+    }
 
 
-	/**
-	 * @brief Check for AMD CPU thread count database if it matches the system's thread count
-	 * @link https://www.amd.com/en/products/specifications/processors.html
-	 * @category x86
+    /**
+     * @brief Check for AMD CPU thread count database if it matches the system's thread count
+     * @link https://www.amd.com/en/products/specifications/processors.html
+     * @category x86
      * @implements VM::AMD_THREAD_MISMATCH
-	 */
-	[[nodiscard]] static bool amd_thread_mismatch() {
+     */
+    [[nodiscard]] static bool amd_thread_mismatch() {
 #if (!x86)
-	    return false;
+        return false;
 #else
         if (!cpu::is_amd()) {
             return false;
@@ -8542,7 +8442,7 @@ private: // START OF PRIVATE VM DETECTION TECHNIQUE DEFINITIONS
         if (cpu::has_hyperthreading()) {
             return false;
         }
-        
+
         std::string model = cpu::get_brand();
 
         for (char& c : model) {
@@ -9117,24 +9017,16 @@ private: // START OF PRIVATE VM DETECTION TECHNIQUE DEFINITIONS
             { "z2 go ", 8 }
         } };
 
-        bool mismatch = false;
-        bool found = false;
-
         for (const auto& pair : amd_thread_database) {
             if (model.find(pair.first) != std::string::npos) {
-                mismatch = (std::thread::hardware_concurrency() != static_cast<unsigned>(pair.second));
-                found = true;
-                break;
+                debug("AMD_THREAD_MISMATCH: Found CPU in database with ", pair.second, " threads");
+                return std::thread::hardware_concurrency() != static_cast<unsigned>(pair.second);
             }
         }
 
-        if (found) {
-            debug("AMD_THREAD_MISMATCH: Unknown brand found for AMD = ", model);
-        }
-
-        return mismatch;
+        return false;
 #endif
-	}
+    }
 
 
     /**
@@ -9146,15 +9038,15 @@ private: // START OF PRIVATE VM DETECTION TECHNIQUE DEFINITIONS
 #if (!WINDOWS)
         return false;
 #else
-    #if (_WIN32_WINNT < _WIN32_WINNT_WIN8)
-            return false;
-    #else
-            BOOL isNativeVhdBoot = 0;
-            if (IsNativeVhdBoot(&isNativeVhdBoot)) {
-                return (isNativeVhdBoot == TRUE);
-            }
-            return false;
-    #endif
+#if (_WIN32_WINNT < _WIN32_WINNT_WIN8)
+        return false;
+#else
+        BOOL isNativeVhdBoot = 0;
+        if (IsNativeVhdBoot(&isNativeVhdBoot)) {
+            return (isNativeVhdBoot == TRUE);
+        }
+        return false;
+#endif
 #endif
     }
 
@@ -9602,36 +9494,36 @@ private: // START OF PRIVATE VM DETECTION TECHNIQUE DEFINITIONS
     }
 
 
-	/**
-	 * @brief Check if the number of accessed files are too low for a human-managed environment
-	 * @category Linux
-	 * @note idea from https://unprotect.it/technique/xbel-recently-opened-files-check/
-	 * @implements VM::FILE_ACCESS_HISTORY
+    /**
+     * @brief Check if the number of accessed files are too low for a human-managed environment
+     * @category Linux
+     * @note idea from https://unprotect.it/technique/xbel-recently-opened-files-check/
+     * @implements VM::FILE_ACCESS_HISTORY
      */
-	[[nodiscard]] static bool file_access_history() {
+    [[nodiscard]] static bool file_access_history() {
 #if (!LINUX)
-	    return false;
+        return false;
 #else 
-	    const std::string xbel_file = util::read_file("~/.local/share/recently-used.xbel");
-	    
+        const std::string xbel_file = util::read_file("~/.local/share/recently-used.xbel");
+
         if (xbel_file.empty()) {
             debug("FILE_ACCESS_HISTORY: file content is empty");
             return false;
         }
-    
-        const std::string key = "href";
-	
-	    u32 count = 0;
-	    std::size_t pos = 0;
-	
-	    while ((pos = xbel_file.find(key, pos)) != std::string::npos) {
-	        count++;
-	        pos += key.length();
-	    }
 
-	    return (count <= 10); 
+        const std::string key = "href";
+
+        u32 count = 0;
+        std::size_t pos = 0;
+
+        while ((pos = xbel_file.find(key, pos)) != std::string::npos) {
+            count++;
+            pos += key.length();
+        }
+
+        return (count <= 10);
 #endif
-	}
+    }
 
 
     /* @brief Check if any waveform-audio output devices are present in the system
@@ -9695,10 +9587,11 @@ private: // START OF PRIVATE VM DETECTION TECHNIQUE DEFINITIONS
         debug("UNKNOWN_MANUFACTURER: CPU brand '", brand, "' did not match known vendor IDs.");
         return true; // no known manufacturer matched, likely a VM
     }
-    
+
 
     /*
      * @brief Check if running xgetbv in the XCR0 extended feature register triggers an exception
+     * @note On pre‑Win8, CR4.OSXSAVE may only get set if you’ve actually loaded an AVX‑enabled binary
      * @category Windows
      * @implements VM::OSXSAVE
      */
@@ -9726,6 +9619,7 @@ private: // START OF PRIVATE VM DETECTION TECHNIQUE DEFINITIONS
             func();
         }
         __except (EXCEPTION_EXECUTE_HANDLER) {
+            VirtualFree(mem, 0, MEM_RELEASE);
             return true;
         }
 
@@ -9736,68 +9630,68 @@ private: // START OF PRIVATE VM DETECTION TECHNIQUE DEFINITIONS
     }
 
 
-	/**
-	 * @brief Check if process status matches with nsjail patterns with PID anomalies
-	 * @category Linux
+    /**
+     * @brief Check if process status matches with nsjail patterns with PID anomalies
+     * @category Linux
      * @implements VM::NSJAIL_PID
-	 */
-	[[nodiscard]] static bool nsjail_proc_id() {
+     */
+    [[nodiscard]] static bool nsjail_proc_id() {
 #if (!LINUX)
         return false;
 #else
-	    std::ifstream status_file("/proc/self/status");
-	    std::string line;
-	    bool pid_match = false;
-	    bool ppid_match = false;
-	
-	    while (std::getline(status_file, line)) {
-	        if (line.find("Pid:") == 0) {
-	            std::string num_str = "";
-	            for (char ch : line) {
-	                if (isdigit(ch)) {
-	                    num_str += ch;
-	                }
-	            }
-	
-	            if (num_str.empty()) {
-	                return false;
-	            }
-	
-	            if (std::stoi(num_str) == 1) {
-	                pid_match = true;
-	            }
-	        }
-	
-	        if (line.find("PPid:") == 0) {
-	            std::string num_str = "";
-	            for (char ch : line) {
-	                if (isdigit(ch)) {
-	                    num_str += ch;
-	                }
-	            }
-	
-	            if (num_str.empty()) {
-	                return false;
-	            }
-	
-	            if (std::stoi(num_str) == 0) {
-	                ppid_match = true;
-	            }
-	        }
-	    }
-	
-	    if (pid_match && ppid_match) {
+        std::ifstream status_file("/proc/self/status");
+        std::string line;
+        bool pid_match = false;
+        bool ppid_match = false;
+
+        while (std::getline(status_file, line)) {
+            if (line.find("Pid:") == 0) {
+                std::string num_str = "";
+                for (char ch : line) {
+                    if (isdigit(ch)) {
+                        num_str += ch;
+                    }
+                }
+
+                if (num_str.empty()) {
+                    return false;
+                }
+
+                if (std::stoi(num_str) == 1) {
+                    pid_match = true;
+                }
+            }
+
+            if (line.find("PPid:") == 0) {
+                std::string num_str = "";
+                for (char ch : line) {
+                    if (isdigit(ch)) {
+                        num_str += ch;
+                    }
+                }
+
+                if (num_str.empty()) {
+                    return false;
+                }
+
+                if (std::stoi(num_str) == 0) {
+                    ppid_match = true;
+                }
+            }
+        }
+
+        if (pid_match && ppid_match) {
             return core::add(brands::NSJAIL);
         }
 
         return false;
 #endif
-	}
+    }
 
 
-	/**
-	 * @brief Check for PCIe bridge names for known VM keywords and brands
-	 * @category Linux
+    /**
+     * @brief Check for PCIe bridge names for known VM keywords and brands
+     * @category Linux
      * @implements VM::PCI_VM
      */
     [[nodiscard]] static bool lspci() {
@@ -9805,32 +9699,33 @@ private: // START OF PRIVATE VM DETECTION TECHNIQUE DEFINITIONS
         return false;
 #else
         if (!(
-            (util::exists("/usr/bin/lspci")) || 
+            (util::exists("/usr/bin/lspci")) ||
             (util::exists("/bin/lspci")) ||
             (util::exists("/usr/sbin/lspci"))
-        )) {
+            )) {
             debug("PCI_VM: ", "binary doesn't exist");
             return false;
         }
 
         const std::unique_ptr<std::string> result = util::sys_result("lspci 2>&1");
-    
+
         if (result == nullptr) {
             debug("PCI_VM: ", "invalid stdout output from lspci");
             return false;
         }
-    
+
         const std::string full_command = *result;
-    
+
         auto pci_finder = [&](const char* str) -> bool {
-            if (util::find(full_command, str)) { 
+            if (util::find(full_command, str)) {
                 debug("PCI_VM: found ", str);
                 return true;
-            } else {
+            }
+            else {
                 return false;
             }
-        };
-    
+            };
+
         if (pci_finder("QEMU PCIe Root port")) { return core::add(brands::QEMU); }
         if (pci_finder("QEMU XHCI Host Controller")) { return core::add(brands::QEMU); }
         if (pci_finder("QXL paravirtual graphic card")) { return core::add(brands::QEMU); }
@@ -9860,10 +9755,10 @@ private: // START OF PRIVATE VM DETECTION TECHNIQUE DEFINITIONS
 
     struct core {
         MSVC_DISABLE_WARNING(PADDING)
-        struct technique {
+            struct technique {
             u8 points = 0;                // this is the certainty score between 0 and 100
             std::function<bool()> run;    // this is the technique function itself
-        
+
             technique() : points(0), run(nullptr) {}
 
             technique(u8 points, std::function<bool()> run) : points(points), run(run) {}
@@ -9876,16 +9771,16 @@ private: // START OF PRIVATE VM DETECTION TECHNIQUE DEFINITIONS
         };
         MSVC_ENABLE_WARNING(PADDING)
 
-        // initial technique list, this is where all the techniques are stored
-        static std::pair<enum_flags, technique> technique_list[];
-    
+            // initial technique list, this is where all the techniques are stored
+            static std::pair<enum_flags, technique> technique_list[];
+
         // the actual table, which is derived from the list above and will be 
         // used for most functionalities related to technique interactions
         static std::map<enum_flags, technique> technique_table;
 
         // specific to VM::add_custom(), where custom techniques will be stored here
         static std::vector<custom_technique> custom_table;
-        
+
         // VM scoreboard table specifically for VM::brand()
         static std::map<const char*, brand_score_t> brand_scoreboard;
 
@@ -9949,7 +9844,7 @@ private: // START OF PRIVATE VM DETECTION TECHNIQUE DEFINITIONS
             if (flags.test(DEFAULT)) {
                 return;
             }
-            
+
             if (flags.test(ALL)) {
                 return;
             }
@@ -9970,9 +9865,10 @@ private: // START OF PRIVATE VM DETECTION TECHNIQUE DEFINITIONS
                 flags.test(DYNAMIC) ||
                 flags.test(NULL_ARG) ||
                 flags.test(MULTIPLE)
-            ) {
+                ) {
                 generate_default(flags);
-            } else {
+            }
+            else {
                 throw std::invalid_argument("Invalid flag option found, aborting");
             }
         }
@@ -9984,7 +9880,7 @@ private: // START OF PRIVATE VM DETECTION TECHNIQUE DEFINITIONS
             const bool memo_enabled = core::is_disabled(flags, NO_MEMO);
 
             u16 threshold_points = 150;
-            
+
             // set it to 300 if high threshold is enabled
             if (core::is_enabled(flags, HIGH_THRESHOLD)) {
                 threshold_points = high_threshold_score;
@@ -10007,7 +9903,7 @@ private: // START OF PRIVATE VM DETECTION TECHNIQUE DEFINITIONS
                 if (
                     (technique_macro == VM::GPU_CAPABILITIES) ||
                     (technique_macro == VM::GPU_VM_STRINGS)
-                ) {
+                    ) {
                     continue;
                 }
 
@@ -10045,9 +9941,9 @@ private: // START OF PRIVATE VM DETECTION TECHNIQUE DEFINITIONS
                 // (unless the threshold is set to be higher, but it's the 
                 // same story here nonetheless, except the threshold is 300)
                 if (
-                    (shortcut) && 
+                    (shortcut) &&
                     (points >= threshold_points)
-                ) {
+                    ) {
                     return points;
                 }
             }
@@ -10079,7 +9975,7 @@ private: // START OF PRIVATE VM DETECTION TECHNIQUE DEFINITIONS
                     if (memo_enabled) {
                         memo::cache_store(
                             technique.id,
-                            result, 
+                            result,
                             technique.points
                         );
                     }
@@ -10094,38 +9990,41 @@ private: // START OF PRIVATE VM DETECTION TECHNIQUE DEFINITIONS
             };
 
             auto merge_scores = [&](
-                const enum_flags a, 
-                const enum_flags b, 
+                const enum_flags a,
+                const enum_flags b,
                 const u8 new_score
-            ) {
-                if (
-                    core::is_disabled(flags, a) ||
-                    core::is_disabled(flags, b)
                 ) {
-                    return;
-                }
-
-                const bool result_a = check(a);
-                const bool result_b = check(b);
-
-                if (result_a && result_b) {
-                    points += new_score;
-                    return;
-                } else if ((result_a == false) && (result_b == false)) {
-                    return;
-                } else {
-                    enum_flags tmp_flag;
-
-                    if (result_a == true) {
-                        tmp_flag = a;
-                    } else {
-                        tmp_flag = b;
+                    if (
+                        core::is_disabled(flags, a) ||
+                        core::is_disabled(flags, b)
+                        ) {
+                        return;
                     }
 
-                    const technique tmp = technique_table.at(tmp_flag);
-                    points += tmp.points;
-                }
-            };
+                    const bool result_a = check(a);
+                    const bool result_b = check(b);
+
+                    if (result_a && result_b) {
+                        points += new_score;
+                        return;
+                    }
+                    else if ((result_a == false) && (result_b == false)) {
+                        return;
+                    }
+                    else {
+                        enum_flags tmp_flag;
+
+                        if (result_a == true) {
+                            tmp_flag = a;
+                        }
+                        else {
+                            tmp_flag = b;
+                        }
+
+                        const technique tmp = technique_table.at(tmp_flag);
+                        points += tmp.points;
+                    }
+                };
 
             merge_scores(GPU_CAPABILITIES, GPU_VM_STRINGS, 100); // instead of 200, it's 100 now
 
@@ -10179,23 +10078,23 @@ private: // START OF PRIVATE VM DETECTION TECHNIQUE DEFINITIONS
 
 
         /**
-         * basically what this entire recursive variadic template inheritance 
-         * fuckery does is manage the variadic arguments being given through 
-         * the arg_handler function, which could either be a std::bitset<N>, 
-         * a uint8_t, or a combination of both of them. This will handle 
-         * both argument types and implement them depending on what their 
-         * types are. If it's a std::bitset<N>, do the |= operation on 
-         * flag_collector. If it's a uint8_t, simply .set() that into the 
+         * basically what this entire recursive variadic template inheritance
+         * fuckery does is manage the variadic arguments being given through
+         * the arg_handler function, which could either be a std::bitset<N>,
+         * a uint8_t, or a combination of both of them. This will handle
+         * both argument types and implement them depending on what their
+         * types are. If it's a std::bitset<N>, do the |= operation on
+         * flag_collector. If it's a uint8_t, simply .set() that into the
          * flag_collector. That's the gist of it.
          *
          * Also I won't even deny, the majority of this section was 90% generated
          * by chatgpt. Can't be arsed with this C++ variadic templatisation shit.
-         * Like is it really my fault that I have a hard time understanging C++'s 
-         * god awful metaprogramming designs? And don't even get me started on SNIFAE. 
-         * 
+         * Like is it really my fault that I have a hard time understanging C++'s
+         * god awful metaprogramming designs? And don't even get me started on SNIFAE.
+         *
          * You don't need an IQ of 3 digits to realise how dogshit this language
          * is, when you end up in situations where there's a few correct solutions
-         * to a problem, but with a billion ways you can do the same thing but in 
+         * to a problem, but with a billion ways you can do the same thing but in
          * the "wrong" way. I genuinely can't wait for Carbon to come out.
          */
     public:
@@ -10241,7 +10140,8 @@ private: // START OF PRIVATE VM DETECTION TECHNIQUE DEFINITIONS
 
             if (disabled_flag_collector.count() == 0) {
                 return;
-            } else {
+            }
+            else {
                 flags &= disabled_flag_collector;
             }
 
@@ -10265,15 +10165,17 @@ private: // START OF PRIVATE VM DETECTION TECHNIQUE DEFINITIONS
             if (
                 (flag == INVALID) ||
                 (flag > enum_size)
-            ) {
+                ) {
                 throw std::invalid_argument("Non-flag or invalid flag provided for VM::detect(), aborting");
             }
 
             if (flag == DEFAULT) {
                 generate_default(flag_collector);
-            } else if (flag == ALL) {
+            }
+            else if (flag == ALL) {
                 generate_all(flag_collector);
-            } else {
+            }
+            else {
                 flag_collector.set(flag);
             }
         }
@@ -10302,7 +10204,7 @@ private: // START OF PRIVATE VM DETECTION TECHNIQUE DEFINITIONS
 
         // Define derived classes for specific type implementations
         struct TestBitsetHandler : public TestHandler {
-            using TestHandler::handle; 
+            using TestHandler::handle;
 
             void handle(const flagset& flags) override {
                 disable_flagset_manager(flags);
@@ -10310,7 +10212,7 @@ private: // START OF PRIVATE VM DETECTION TECHNIQUE DEFINITIONS
         };
 
         struct TestUint8Handler : public TestHandler {
-            using TestHandler::handle;  
+            using TestHandler::handle;
 
             void handle(const enum_flags flag) override {
                 flag_manager(flag);
@@ -10318,7 +10220,7 @@ private: // START OF PRIVATE VM DETECTION TECHNIQUE DEFINITIONS
         };
 
         struct DisableTestUint8Handler : public DisableTestHandler {
-            using DisableTestHandler::disable_handle;  
+            using DisableTestHandler::disable_handle;
 
             void disable_handle(const enum_flags flag) override {
                 disable_flag_manager(flag);
@@ -10361,9 +10263,11 @@ private: // START OF PRIVATE VM DETECTION TECHNIQUE DEFINITIONS
 
             if (isType<flagset>(first)) {
                 dispatch(first, bitsetHandler);
-            } else if (isType<enum_flags>(first)) {
+            }
+            else if (isType<enum_flags>(first)) {
                 dispatch(first, uint8Handler);
-            } else {
+            }
+            else {
                 const std::string msg =
                     "Arguments must either be a std::bitset<" +
                     std::to_string(static_cast<u32>(enum_size + 1)) +
@@ -10383,9 +10287,11 @@ private: // START OF PRIVATE VM DETECTION TECHNIQUE DEFINITIONS
 
             if (isType<flagset>(first)) {
                 throw std::invalid_argument("Arguments must not contain VM::DEFAULT or VM::ALL, only technique flags are accepted (view the documentation for a full list)");
-            } else if (isType<enum_flags>(first)) {
+            }
+            else if (isType<enum_flags>(first)) {
                 disable_dispatch(first, Disableuint8Handler);
-            } else {
+            }
+            else {
                 throw std::invalid_argument("Arguments must be a technique flag, aborting");
             }
 
@@ -10413,7 +10319,7 @@ private: // START OF PRIVATE VM DETECTION TECHNIQUE DEFINITIONS
             flag_collector.reset();
             generate_default(disabled_flag_collector);
 
-            if VMAWARE_CONSTEXPR (is_empty<Args...>()) {
+            if VMAWARE_CONSTEXPR(is_empty<Args...>()) {
                 generate_default(flag_collector);
                 return flag_collector;
             }
@@ -10421,7 +10327,7 @@ private: // START OF PRIVATE VM DETECTION TECHNIQUE DEFINITIONS
             // set the bits in the flag, can take in 
             // either an enum value or a std::bitset
             handleArgs(std::forward<Args>(args)...);
-            
+
             if (flag_collector.count() == 0) {
                 generate_default(flag_collector);
             }
@@ -10457,7 +10363,7 @@ private: // START OF PRIVATE VM DETECTION TECHNIQUE DEFINITIONS
 
             generate_default(disabled_flag_collector);
 
-            if VMAWARE_CONSTEXPR (is_empty<Args...>()) {
+            if VMAWARE_CONSTEXPR(is_empty<Args...>()) {
                 throw std::invalid_argument("VM::DISABLE() must contain a flag");
             }
 
@@ -10531,7 +10437,7 @@ public: // START OF PUBLIC FUNCTIONS
      * @link https://github.com/kernelwernel/VMAware/blob/main/docs/documentation.md#vmcheck
      */
     static bool check(
-        const enum_flags flag_bit, 
+        const enum_flags flag_bit,
         const enum_flags memo_arg = NULL_ARG
         // clang doesn't support std::source_location for some reason
 #if (CPP >= 20 && !CLANG)
@@ -10546,7 +10452,7 @@ public: // START OF PUBLIC FUNCTIONS
 #endif
             ss << ". Consult the documentation's flag handler for VM::check()";
             throw std::invalid_argument(std::string(text) + ss.str());
-        };
+            };
 
         // check if flag is out of range
         if (flag_bit > enum_size) {
@@ -10559,14 +10465,14 @@ public: // START OF PUBLIC FUNCTIONS
             (flag_bit == HIGH_THRESHOLD) ||
             (flag_bit == DYNAMIC) ||
             (flag_bit == MULTIPLE)
-        ) {
+            ) {
             throw_error("Flag argument must be a technique flag and not a settings flag");
         }
 
         if (
-            (memo_arg != NO_MEMO) && 
+            (memo_arg != NO_MEMO) &&
             (memo_arg != NULL_ARG)
-        ) {
+            ) {
             throw_error("Flag argument for memoization must be either VM::NO_MEMO or left empty");
         }
 
@@ -10639,7 +10545,8 @@ public: // START OF PUBLIC FUNCTIONS
                     core_debug("VM::brand(): returned multi brand from cache");
                     return memo::multi_brand::fetch();
                 }
-            } else {
+            }
+            else {
                 if (memo::brand::is_cached()) {
                     core_debug("VM::brand(): returned brand from cache");
                     return memo::brand::fetch();
@@ -10698,7 +10605,7 @@ public: // START OF PUBLIC FUNCTIONS
         std::map<const char*, brand_score_t> brands;
 
         // add the relevant brands with at least 1 point
-        for (const auto &element : core::brand_scoreboard) {
+        for (const auto& element : core::brand_scoreboard) {
             if (element.second > 0) {
                 brands.insert(std::make_pair(element.first, element.second));
             }
@@ -10717,7 +10624,7 @@ public: // START OF PUBLIC FUNCTIONS
         if (brands.size() == 1) {
             return brands.begin()->first;
         }
-        
+
         // remove Hyper-V artifacts if found with other 
         // brands, because that's not a VM. It's added 
         // only for the sake of information cuz of the 
@@ -10733,12 +10640,12 @@ public: // START OF PUBLIC FUNCTIONS
             if (
                 (brands.count(a) > 0) &&
                 (brands.count(b) > 0)
-            ) {
+                ) {
                 brands.erase(a);
                 brands.erase(b);
                 brands.emplace(std::make_pair(result, 2));
             }
-        };
+            };
 
         // same as above, but for 3
         auto triple_merge = [&](const char* a, const char* b, const char* c, const char* result) -> void {
@@ -10746,13 +10653,13 @@ public: // START OF PUBLIC FUNCTIONS
                 (brands.count(a) > 0) &&
                 (brands.count(b) > 0) &&
                 (brands.count(c) > 0)
-            ) {
+                ) {
                 brands.erase(a);
                 brands.erase(b);
                 brands.erase(c);
                 brands.emplace(std::make_pair(result, 2));
             }
-        };
+            };
 
 
         // some edgecase handling for Hyper-V and VirtualPC since
@@ -10760,11 +10667,12 @@ public: // START OF PUBLIC FUNCTIONS
         if ((brands.count(TMP_HYPERV) > 0) && (brands.count(TMP_VPC) > 0)) {
             if (brands.count(TMP_HYPERV) == brands.count(TMP_VPC)) {
                 merge(TMP_VPC, TMP_HYPERV, TMP_HYPERV_VPC);
-            } else {
+            }
+            else {
                 brands.erase(TMP_VPC);
             }
         }
-        
+
 
         // this is the section where brand post-processing will be done. 
         // The reason why this part is necessary is because it will
@@ -10777,35 +10685,35 @@ public: // START OF PUBLIC FUNCTIONS
         // brand is "Azure Hyper-V" instead of just "Hyper-V". So what
         // this section does is "merge" the brands together to form
         // a more accurate idea of the brand(s) involved.
-        merge(TMP_AZURE, TMP_HYPERV,     TMP_AZURE);
-        merge(TMP_AZURE, TMP_VPC,        TMP_AZURE);
+        merge(TMP_AZURE, TMP_HYPERV, TMP_AZURE);
+        merge(TMP_AZURE, TMP_VPC, TMP_AZURE);
         merge(TMP_AZURE, TMP_HYPERV_VPC, TMP_AZURE);
 
-        merge(TMP_NANOVISOR, TMP_HYPERV,     TMP_NANOVISOR);
-        merge(TMP_NANOVISOR, TMP_VPC,        TMP_NANOVISOR);
+        merge(TMP_NANOVISOR, TMP_HYPERV, TMP_NANOVISOR);
+        merge(TMP_NANOVISOR, TMP_VPC, TMP_NANOVISOR);
         merge(TMP_NANOVISOR, TMP_HYPERV_VPC, TMP_NANOVISOR);
-        
-        merge(TMP_QEMU,     TMP_KVM,        TMP_QEMU_KVM);
-        merge(TMP_KVM,      TMP_HYPERV,     TMP_KVM_HYPERV);
-        merge(TMP_QEMU,     TMP_HYPERV,     TMP_QEMU_KVM_HYPERV);
-        merge(TMP_QEMU_KVM, TMP_HYPERV,     TMP_QEMU_KVM_HYPERV);
-        merge(TMP_KVM,      TMP_KVM_HYPERV, TMP_KVM_HYPERV);
-        merge(TMP_QEMU,     TMP_KVM_HYPERV, TMP_QEMU_KVM_HYPERV);
+
+        merge(TMP_QEMU, TMP_KVM, TMP_QEMU_KVM);
+        merge(TMP_KVM, TMP_HYPERV, TMP_KVM_HYPERV);
+        merge(TMP_QEMU, TMP_HYPERV, TMP_QEMU_KVM_HYPERV);
+        merge(TMP_QEMU_KVM, TMP_HYPERV, TMP_QEMU_KVM_HYPERV);
+        merge(TMP_KVM, TMP_KVM_HYPERV, TMP_KVM_HYPERV);
+        merge(TMP_QEMU, TMP_KVM_HYPERV, TMP_QEMU_KVM_HYPERV);
         merge(TMP_QEMU_KVM, TMP_KVM_HYPERV, TMP_QEMU_KVM_HYPERV);
 
         triple_merge(TMP_QEMU, TMP_KVM, TMP_KVM_HYPERV, TMP_QEMU_KVM_HYPERV);
 
-        merge(TMP_VMWARE, TMP_FUSION,      TMP_FUSION);
-        merge(TMP_VMWARE, TMP_EXPRESS,     TMP_EXPRESS);
-        merge(TMP_VMWARE, TMP_ESX,         TMP_ESX);
-        merge(TMP_VMWARE, TMP_GSX,         TMP_GSX);
+        merge(TMP_VMWARE, TMP_FUSION, TMP_FUSION);
+        merge(TMP_VMWARE, TMP_EXPRESS, TMP_EXPRESS);
+        merge(TMP_VMWARE, TMP_ESX, TMP_ESX);
+        merge(TMP_VMWARE, TMP_GSX, TMP_GSX);
         merge(TMP_VMWARE, TMP_WORKSTATION, TMP_WORKSTATION);
 
-        merge(TMP_VMWARE_HARD, TMP_VMWARE,      TMP_VMWARE_HARD);
-        merge(TMP_VMWARE_HARD, TMP_FUSION,      TMP_VMWARE_HARD);
-        merge(TMP_VMWARE_HARD, TMP_EXPRESS,     TMP_VMWARE_HARD);
-        merge(TMP_VMWARE_HARD, TMP_ESX,         TMP_VMWARE_HARD);
-        merge(TMP_VMWARE_HARD, TMP_GSX,         TMP_VMWARE_HARD);
+        merge(TMP_VMWARE_HARD, TMP_VMWARE, TMP_VMWARE_HARD);
+        merge(TMP_VMWARE_HARD, TMP_FUSION, TMP_VMWARE_HARD);
+        merge(TMP_VMWARE_HARD, TMP_EXPRESS, TMP_VMWARE_HARD);
+        merge(TMP_VMWARE_HARD, TMP_ESX, TMP_VMWARE_HARD);
+        merge(TMP_VMWARE_HARD, TMP_GSX, TMP_VMWARE_HARD);
         merge(TMP_VMWARE_HARD, TMP_WORKSTATION, TMP_VMWARE_HARD);
 
 
@@ -10837,11 +10745,11 @@ public: // START OF PUBLIC FUNCTIONS
         // sort the relevant brands vector so that the brands with 
         // the highest score appears first in descending order
         std::sort(vec.begin(), vec.end(), [](
-            const brand_element_t &a,
-            const brand_element_t &b
-        ) {
-            return a.second > b.second;
-        });
+            const brand_element_t& a,
+            const brand_element_t& b
+            ) {
+                return a.second > b.second;
+            });
 
         std::string ret_str = brands::NULL_BRAND;
 
@@ -10854,7 +10762,8 @@ public: // START OF PUBLIC FUNCTIONS
         // See VM::MULTIPLE flag in docs for more information.
         if (!is_multiple) {
             ret_str = vec.front().first;
-        } else {
+        }
+        else {
             std::stringstream ss;
             std::size_t i = 1;
 
@@ -10873,12 +10782,13 @@ public: // START OF PUBLIC FUNCTIONS
             if (is_multiple) {
                 core_debug("VM::brand(): cached multiple brand string");
                 memo::multi_brand::store(ret_str);
-            } else {
+            }
+            else {
                 core_debug("VM::brand(): cached brand string");
                 memo::brand::store(ret_str);
             }
         }
-        
+
 
         // debug stuff to see the brand scoreboard, ignore this
 #ifdef __VMAWARE_DEBUG__
@@ -10955,9 +10865,11 @@ public: // START OF PUBLIC FUNCTIONS
         // above 150 to get to 100% 
         if (points >= threshold) {
             percent = 100;
-        } else if (points >= 100) {
+        }
+        else if (points >= 100) {
             percent = 99;
-        } else {
+        }
+        else {
             percent = static_cast<u8>(points);
         }
 
@@ -10987,7 +10899,7 @@ public: // START OF PUBLIC FUNCTIONS
 #endif
             ss << ". Consult the documentation's parameters for VM::add_custom()";
             throw std::invalid_argument(std::string(text) + ss.str());
-        };
+            };
 
         if (percent > 100) {
             throw_error("Percentage parameter must be between 0 and 100");
@@ -11037,111 +10949,105 @@ public: // START OF PUBLIC FUNCTIONS
      */
     [[nodiscard]] static std::string flag_to_string(const enum_flags flag) {
         switch (flag) {
-          case VMID: return "VMID";
-          case CPU_BRAND: return "CPU_BRAND";
-          case HYPERVISOR_BIT: return "HYPERVISOR_BIT";
-          case HYPERVISOR_STR: return "HYPERVISOR_STR";
-          case TIMER: return "TIMER";
-          case THREADCOUNT: return "THREADCOUNT";
-          case MAC: return "MAC";
-          case TEMPERATURE: return "TEMPERATURE";
-          case SYSTEMD: return "SYSTEMD";
-          case CVENDOR: return "CVENDOR";
-          case CTYPE: return "CTYPE";
-          case DOCKERENV: return "DOCKERENV";
-          case DMIDECODE: return "DMIDECODE";
-          case DMESG: return "DMESG";
-          case HWMON: return "HWMON";
-          case SIDT5: return "SIDT5";
-          case DLL: return "DLL";
-          case REGISTRY: return "REGISTRY";
-          case VM_FILES: return "VM_FILES";
-          case HWMODEL: return "HWMODEL";
-          case DISK_SIZE: return "DISK_SIZE";
-          case VBOX_DEFAULT: return "VBOX_DEFAULT";
-          case VBOX_NETWORK: return "VBOX_NETWORK";
-          case VM_PROCESSES: return "VM_PROCESSES";
-          case LINUX_USER_HOST: return "LINUX_USER_HOST";
-          case GAMARUE: return "GAMARUE";
-          case BOCHS_CPU: return "BOCHS_CPU";
-          case MSSMBIOS: return "MSSMBIOS";
-          case MAC_MEMSIZE: return "MAC_MEMSIZE";
-          case MAC_IOKIT: return "MAC_IOKIT";
-          case IOREG_GREP: return "IOREG_GREP";
-          case MAC_SIP: return "MAC_SIP";
-          case HKLM_REGISTRIES: return "HKLM_REGISTRIES";
-          case VPC_INVALID: return "VPC_INVALID";
-          case SIDT: return "SIDT";
-          case SGDT: return "SGDT";
-          case SLDT: return "SLDT";
-          case OFFSEC_SIDT: return "OFFSEC_SIDT";
-          case OFFSEC_SGDT: return "OFFSEC_SGDT";
-          case OFFSEC_SLDT: return "OFFSEC_SLDT";
-          case VPC_SIDT: return "VPC_SIDT";
-          case VMWARE_IOMEM: return "VMWARE_IOMEM";
-          case VMWARE_IOPORTS: return "VMWARE_IOPORTS";
-          case VMWARE_SCSI: return "VMWARE_SCSI";
-          case VMWARE_DMESG: return "VMWARE_DMESG";
-          case VMWARE_STR: return "VMWARE_STR";
-          case VMWARE_BACKDOOR: return "VMWARE_BACKDOOR";
-          case VMWARE_PORT_MEM: return "VMWARE_PORT_MEM";
-          case SMSW: return "SMSW";
-          case MUTEX: return "MUTEX";
-          case ODD_CPU_THREADS: return "ODD_CPU_THREADS";
-          case INTEL_THREAD_MISMATCH: return "INTEL_THREAD_MISMATCH";
-          case XEON_THREAD_MISMATCH: return "XEON_THREAD_MISMATCH";
-          case NETTITUDE_VM_MEMORY: return "NETTITUDE_VM_MEMORY";
-          case CUCKOO_DIR: return "CUCKOO_DIR";
-          case CUCKOO_PIPE: return "CUCKOO_PIPE";
-          case HYPERV_HOSTNAME: return "HYPERV_HOSTNAME";
-          case GENERAL_HOSTNAME: return "GENERAL_HOSTNAME";
-          case SCREEN_RESOLUTION: return "SCREEN_RESOLUTION";
-          case DEVICE_STRING: return "DEVICE_STRING";
-          case BLUESTACKS_FOLDERS: return "BLUESTACKS_FOLDERS";
-          case CPUID_SIGNATURE: return "CPUID_SIGNATURE";
-          case KVM_BITMASK: return "KVM_BITMASK";
-          case KGT_SIGNATURE: return "KGT_SIGNATURE";
-          case QEMU_VIRTUAL_DMI: return "QEMU_VIRTUAL_DMI";
-          case QEMU_USB: return "QEMU_USB";
-          case HYPERVISOR_DIR: return "HYPERVISOR_DIR";
-          case UML_CPU: return "UML_CPU";
-          case KMSG: return "KMSG";
-          case VM_PROCS: return "VM_PROCS";
-          case VBOX_MODULE: return "VBOX_MODULE";
-          case SYSINFO_PROC: return "SYSINFO_PROC";
-          case DEVICE_TREE: return "DEVICE_TREE";
-          case DMI_SCAN: return "DMI_SCAN";
-          case SMBIOS_VM_BIT: return "SMBIOS_VM_BIT";
-          case PODMAN_FILE: return "PODMAN_FILE";
-          case WSL_PROC: return "WSL_PROC";
-          case DRIVER_NAMES: return "DRIVER_NAMES";
-          case VM_SIDT: return "VM_SIDT";
-          case DISK_SERIAL: return "DISK_SERIAL";
-          case PORT_CONNECTORS: return "PORT_CONNECTORS";
-          case GPU_VM_STRINGS: return "GPU_STRINGS";
-          case GPU_CAPABILITIES: return "GPU_CAPABILITIES";
-          case VM_DEVICES: return "VM_DEVICES";
-          case PROCESSOR_NUMBER: return "PROCESSOR_NUMBER";
-          case NUMBER_OF_CORES: return "NUMBER_OF_CORES";
-          case ACPI_TEMPERATURE: return "ACPI_TEMPERATURE";
-          case SYS_QEMU: return "SYS_QEMU";
-          case LSHW_QEMU: return "LSHW_QEMU";
-          case VIRTUAL_PROCESSORS: return "VIRTUAL_PROCESSORS";
-          case HYPERV_QUERY: return "HYPERV_QUERY";
-          case BAD_POOLS: return "BAD_POOLS";
-          case AMD_SEV: return "AMD_SEV";
-          case AMD_THREAD_MISMATCH: return "AMD_THREAD_MISMATCH";
-          case NATIVE_VHD: return "NATIVE_VHD";
-          case VIRTUAL_REGISTRY: return "VIRTUAL_REGISTRY";
-          case FIRMWARE: return "FIRMWARE";
-          case FILE_ACCESS_HISTORY: return "FILE_ACCESS_HISTORY";
-          case AUDIO: return "AUDIO";
-          case UNKNOWN_MANUFACTURER: return "UNKNOWN_MANUFACTURER";
-          case OSXSAVE: return "OSXSAVE";
-          case NSJAIL_PID: return "NSJAIL_PID";
-          case PCI_VM: return "PCI_VM";
-          // ADD NEW CASE HERE FOR NEW TECHNIQUE
-          default: return "Unknown flag";
+        case VMID: return "VMID";
+        case CPU_BRAND: return "CPU_BRAND";
+        case HYPERVISOR_BIT: return "HYPERVISOR_BIT";
+        case HYPERVISOR_STR: return "HYPERVISOR_STR";
+        case TIMER: return "TIMER";
+        case THREADCOUNT: return "THREADCOUNT";
+        case MAC: return "MAC";
+        case TEMPERATURE: return "TEMPERATURE";
+        case SYSTEMD: return "SYSTEMD";
+        case CVENDOR: return "CVENDOR";
+        case CTYPE: return "CTYPE";
+        case DOCKERENV: return "DOCKERENV";
+        case DMIDECODE: return "DMIDECODE";
+        case DMESG: return "DMESG";
+        case HWMON: return "HWMON";
+        case DLL: return "DLL";
+        case REGISTRY: return "REGISTRY";
+        case VM_FILES: return "VM_FILES";
+        case HWMODEL: return "HWMODEL";
+        case DISK_SIZE: return "DISK_SIZE";
+        case VBOX_DEFAULT: return "VBOX_DEFAULT";
+        case VBOX_NETWORK: return "VBOX_NETWORK";
+        case VM_PROCESSES: return "VM_PROCESSES";
+        case LINUX_USER_HOST: return "LINUX_USER_HOST";
+        case GAMARUE: return "GAMARUE";
+        case BOCHS_CPU: return "BOCHS_CPU";
+        case MSSMBIOS: return "MSSMBIOS";
+        case MAC_MEMSIZE: return "MAC_MEMSIZE";
+        case MAC_IOKIT: return "MAC_IOKIT";
+        case IOREG_GREP: return "IOREG_GREP";
+        case MAC_SIP: return "MAC_SIP";
+        case HKLM_REGISTRIES: return "HKLM_REGISTRIES";
+        case VPC_INVALID: return "VPC_INVALID";
+        case SIDT: return "SIDT";
+        case SGDT: return "SGDT";
+        case SLDT: return "SLDT";
+        case VMWARE_IOMEM: return "VMWARE_IOMEM";
+        case VMWARE_IOPORTS: return "VMWARE_IOPORTS";
+        case VMWARE_SCSI: return "VMWARE_SCSI";
+        case VMWARE_DMESG: return "VMWARE_DMESG";
+        case VMWARE_STR: return "VMWARE_STR";
+        case VMWARE_BACKDOOR: return "VMWARE_BACKDOOR";
+        case VMWARE_PORT_MEM: return "VMWARE_PORT_MEM";
+        case SMSW: return "SMSW";
+        case MUTEX: return "MUTEX";
+        case ODD_CPU_THREADS: return "ODD_CPU_THREADS";
+        case INTEL_THREAD_MISMATCH: return "INTEL_THREAD_MISMATCH";
+        case XEON_THREAD_MISMATCH: return "XEON_THREAD_MISMATCH";
+        case NETTITUDE_VM_MEMORY: return "NETTITUDE_VM_MEMORY";
+        case CUCKOO_DIR: return "CUCKOO_DIR";
+        case CUCKOO_PIPE: return "CUCKOO_PIPE";
+        case HYPERV_HOSTNAME: return "HYPERV_HOSTNAME";
+        case GENERAL_HOSTNAME: return "GENERAL_HOSTNAME";
+        case SCREEN_RESOLUTION: return "SCREEN_RESOLUTION";
+        case DEVICE_STRING: return "DEVICE_STRING";
+        case BLUESTACKS_FOLDERS: return "BLUESTACKS_FOLDERS";
+        case CPUID_SIGNATURE: return "CPUID_SIGNATURE";
+        case KVM_BITMASK: return "KVM_BITMASK";
+        case KGT_SIGNATURE: return "KGT_SIGNATURE";
+        case QEMU_VIRTUAL_DMI: return "QEMU_VIRTUAL_DMI";
+        case QEMU_USB: return "QEMU_USB";
+        case HYPERVISOR_DIR: return "HYPERVISOR_DIR";
+        case UML_CPU: return "UML_CPU";
+        case KMSG: return "KMSG";
+        case VM_PROCS: return "VM_PROCS";
+        case VBOX_MODULE: return "VBOX_MODULE";
+        case SYSINFO_PROC: return "SYSINFO_PROC";
+        case DEVICE_TREE: return "DEVICE_TREE";
+        case DMI_SCAN: return "DMI_SCAN";
+        case SMBIOS_VM_BIT: return "SMBIOS_VM_BIT";
+        case PODMAN_FILE: return "PODMAN_FILE";
+        case WSL_PROC: return "WSL_PROC";
+        case DRIVER_NAMES: return "DRIVER_NAMES";
+        case DISK_SERIAL: return "DISK_SERIAL";
+        case PORT_CONNECTORS: return "PORT_CONNECTORS";
+        case GPU_VM_STRINGS: return "GPU_STRINGS";
+        case GPU_CAPABILITIES: return "GPU_CAPABILITIES";
+        case VM_DEVICES: return "VM_DEVICES";
+        case PROCESSOR_NUMBER: return "PROCESSOR_NUMBER";
+        case NUMBER_OF_CORES: return "NUMBER_OF_CORES";
+        case ACPI_TEMPERATURE: return "ACPI_TEMPERATURE";
+        case SYS_QEMU: return "SYS_QEMU";
+        case LSHW_QEMU: return "LSHW_QEMU";
+        case VIRTUAL_PROCESSORS: return "VIRTUAL_PROCESSORS";
+        case HYPERV_QUERY: return "HYPERV_QUERY";
+        case BAD_POOLS: return "BAD_POOLS";
+        case AMD_SEV: return "AMD_SEV";
+        case AMD_THREAD_MISMATCH: return "AMD_THREAD_MISMATCH";
+        case NATIVE_VHD: return "NATIVE_VHD";
+        case VIRTUAL_REGISTRY: return "VIRTUAL_REGISTRY";
+        case FIRMWARE: return "FIRMWARE";
+        case FILE_ACCESS_HISTORY: return "FILE_ACCESS_HISTORY";
+        case AUDIO: return "AUDIO";
+        case UNKNOWN_MANUFACTURER: return "UNKNOWN_MANUFACTURER";
+        case OSXSAVE: return "OSXSAVE";
+        case NSJAIL_PID: return "NSJAIL_PID";
+        case PCI_VM: return "PCI_VM";
+            // ADD NEW CASE HERE FOR NEW TECHNIQUE
+        default: return "Unknown flag";
         }
     }
 
@@ -11163,7 +11069,7 @@ public: // START OF PUBLIC FUNCTIONS
             if (
                 (flags.test(technique_enum)) &&
                 (check(static_cast<enum_flags>(technique_enum)))
-            ) {
+                ) {
                 tmp.push_back(static_cast<enum_flags>(technique_enum));
             }
         }
@@ -11194,7 +11100,7 @@ public: // START OF PUBLIC FUNCTIONS
 #endif
             ss << ". Consult the documentation's parameters for VM::modify_score()";
             throw std::invalid_argument(std::string(text) + ss.str());
-        };
+            };
 
         if (percent > 100) {
             throw_error("Percentage parameter must be between 0 and 100");
@@ -11209,13 +11115,13 @@ public: // START OF PUBLIC FUNCTIONS
             throw_error("The flag is not a technique flag");
         }
 
-        using table_t =  std::map<enum_flags, core::technique>;
+        using table_t = std::map<enum_flags, core::technique>;
 
-        auto modify = [](table_t &table, const enum_flags flag, const u8 percent) -> void {
-            core::technique &tmp = table.at(flag);
+        auto modify = [](table_t& table, const enum_flags flag, const u8 percent) -> void {
+            core::technique& tmp = table.at(flag);
             table[flag].points = percent;
             table[flag].run = tmp.run;
-        };
+            };
 
         modify(core::technique_table, flag, percent);
     }
@@ -11253,7 +11159,7 @@ public: // START OF PUBLIC FUNCTIONS
             return "Unknown";
         }
 
-        const std::map<std::string, const char*> type_table {
+        const std::map<std::string, const char*> type_table{
             // type 1
             { brands::XEN, "Hypervisor (type 1)" },
             { brands::VMWARE_ESX, "Hypervisor (type 1)" },
@@ -11361,13 +11267,13 @@ public: // START OF PUBLIC FUNCTIONS
         const std::string very_likely = "Very likely";
         const std::string inside_vm = "Running inside";
 
-        auto make_conclusion = [&](const std::string &category) -> std::string {
+        auto make_conclusion = [&](const std::string& category) -> std::string {
             // this basically just fixes the grammatical syntax
             // by either having "a" or "an" before the VM brand
             // name, like it would look weird if the conclusion 
             // message was "an VirtualBox" or "a Anubis", so this
             // section fixes that issue.
-            std::string article = "";   
+            std::string article = "";
 
             if (
                 (brand_tmp == brands::ACRN) ||
@@ -11386,9 +11292,10 @@ public: // START OF PUBLIC FUNCTIONS
                 (brand_tmp == brands::AMD_SEV_SNP) ||
                 (brand_tmp == brands::NSJAIL) ||
                 (brand_tmp == brands::NULL_BRAND)
-            ) {
+                ) {
                 article = " an ";
-            } else {
+            }
+            else {
                 article = " a ";
             }
 
@@ -11400,31 +11307,33 @@ public: // START OF PUBLIC FUNCTIONS
 
             // Hyper-V artifacts are an exception due to how unique the circumstance is
             if (brand_tmp == brands::HYPERV_ARTIFACT) {
-               return (category + article + brand_tmp);
-            } else {
+                return (category + article + brand_tmp);
+            }
+            else {
                 return (category + article + brand_tmp + " VM");
             }
-        };
+            };
 
         if (core::is_enabled(flags, DYNAMIC)) {
-            if      (percent_tmp == 0)   { return baremetal; } 
-            else if (percent_tmp <= 20)  { return very_unlikely; } 
-            else if (percent_tmp <= 35)  { return unlikely; } 
-            else if (percent_tmp < 50)   { return make_conclusion(potentially); } 
-            else if (percent_tmp <= 62)  { return make_conclusion(might); } 
-            else if (percent_tmp <= 75)  { return make_conclusion(likely); } 
-            else if (percent_tmp < 100)  { return make_conclusion(very_likely); } 
-            else                         { return make_conclusion(inside_vm); }
+            if (percent_tmp == 0) { return baremetal; }
+            else if (percent_tmp <= 20) { return very_unlikely; }
+            else if (percent_tmp <= 35) { return unlikely; }
+            else if (percent_tmp < 50) { return make_conclusion(potentially); }
+            else if (percent_tmp <= 62) { return make_conclusion(might); }
+            else if (percent_tmp <= 75) { return make_conclusion(likely); }
+            else if (percent_tmp < 100) { return make_conclusion(very_likely); }
+            else { return make_conclusion(inside_vm); }
         }
 
         if (percent_tmp == 100) {
             return make_conclusion(inside_vm);
-        } else {
+        }
+        else {
             return baremetal;
         }
     }
 
-    #pragma pack(push, 1)
+#pragma pack(push, 1)
     struct vmaware {
         std::string brand;
         std::string type;
@@ -11447,7 +11356,7 @@ public: // START OF PUBLIC FUNCTIONS
             technique_count = VM::technique_count;
         }
     };
-    #pragma pack(pop)
+#pragma pack(pop)
 
 
     static u16 technique_count; // get total number of techniques
@@ -11455,7 +11364,7 @@ public: // START OF PUBLIC FUNCTIONS
 #ifdef __VMAWARE_DEBUG__
     static u16 total_points;
 #endif
-};
+    };
 
 MSVC_ENABLE_WARNING(ASSIGNMENT_OPERATOR NO_INLINE_FUNC SPECTRE)
 
@@ -11572,7 +11481,7 @@ std::vector<VM::u8> VM::technique_vector = []() -> std::vector<VM::u8> {
     }
 
     return tmp;
-}();
+    }();
 
 
 // this value is incremented each time VM::add_custom is called
@@ -11604,7 +11513,6 @@ std::pair<VM::enum_flags, VM::core::technique> VM::core::technique_list[] = {
     std::make_pair(VM::DMIDECODE, VM::core::technique(55, VM::dmidecode)),
     std::make_pair(VM::DMESG, VM::core::technique(55, VM::dmesg)),
     std::make_pair(VM::HWMON, VM::core::technique(35, VM::hwmon)),
-    std::make_pair(VM::SIDT5, VM::core::technique(45, VM::sidt5)),
     std::make_pair(VM::DLL, VM::core::technique(25, VM::dll_check)),
     std::make_pair(VM::REGISTRY, VM::core::technique(50, VM::registry_key)),
     std::make_pair(VM::VM_FILES, VM::core::technique(25, VM::vm_files)),
@@ -11626,10 +11534,6 @@ std::pair<VM::enum_flags, VM::core::technique> VM::core::technique_list[] = {
     std::make_pair(VM::SIDT, VM::core::technique(25, VM::sidt)),
     std::make_pair(VM::SGDT, VM::core::technique(30, VM::sgdt)),
     std::make_pair(VM::SLDT, VM::core::technique(15, VM::sldt)),
-    std::make_pair(VM::OFFSEC_SIDT, VM::core::technique(60, VM::offsec_sidt)),
-    std::make_pair(VM::OFFSEC_SGDT, VM::core::technique(60, VM::offsec_sgdt)),
-    std::make_pair(VM::OFFSEC_SLDT, VM::core::technique(20, VM::offsec_sldt)),
-    std::make_pair(VM::VPC_SIDT, VM::core::technique(15, VM::vpc_sidt)),
     std::make_pair(VM::VMWARE_IOMEM, VM::core::technique(65, VM::vmware_iomem)),
     std::make_pair(VM::VMWARE_IOPORTS, VM::core::technique(70, VM::vmware_ioports)),
     std::make_pair(VM::VMWARE_SCSI, VM::core::technique(40, VM::vmware_scsi)),
@@ -11668,7 +11572,6 @@ std::pair<VM::enum_flags, VM::core::technique> VM::core::technique_list[] = {
     std::make_pair(VM::PODMAN_FILE, VM::core::technique(5, VM::podman_file)),
     std::make_pair(VM::WSL_PROC, VM::core::technique(30, VM::wsl_proc_subdir)),
     std::make_pair(VM::DRIVER_NAMES, VM::core::technique(100, VM::driver_names)),
-    std::make_pair(VM::VM_SIDT, VM::core::technique(100, VM::vm_sidt)),
     std::make_pair(VM::DISK_SERIAL, VM::core::technique(100, VM::disk_serial_number)),
     std::make_pair(VM::PORT_CONNECTORS, VM::core::technique(25, VM::port_connectors)),
     std::make_pair(VM::GPU_VM_STRINGS, VM::core::technique(100, VM::gpu_vm_strings)),
@@ -11704,4 +11607,4 @@ table_t VM::core::technique_table = []() -> table_t {
         table.insert(technique);
     }
     return table;
-}();
+    }();

--- a/src/vmaware_MIT.hpp
+++ b/src/vmaware_MIT.hpp
@@ -49,14 +49,14 @@
  *
  *
  * ============================== SECTIONS ==================================
- * - enums for publicly accessible techniques  => line 555
- * - struct for internal cpu operations        => line 754
- * - struct for internal memoization           => line 1226
- * - struct for internal utility functions     => line 1351
- * - struct for internal core components       => line 9756
- * - start of VM detection technique list      => line 2380
- * - start of public VM detection functions    => line 10431
- * - start of externally defined variables     => line 11372
+ * - enums for publicly accessible techniques  => line 573
+ * - struct for internal cpu operations        => line 750
+ * - struct for internal memoization           => line 1222
+ * - struct for internal utility functions     => line 1347
+ * - struct for internal core components       => line 9752
+ * - start of VM detection technique list      => line 2376
+ * - start of public VM detection functions    => line 10427
+ * - start of externally defined variables     => line 11368
  *
  *
  * ============================== EXAMPLE ===================================
@@ -390,8 +390,6 @@
 #include <mmsystem.h>
 #include <dxgi.h>
 #include <d3d9.h>
-#include <d3d11.h>
-#include <d3d12.h>
 
 #pragma comment(lib, "winmm.lib")
 #pragma comment(lib, "setupapi.lib")
@@ -405,10 +403,8 @@
 #pragma comment(lib, "uuid.lib")
 #pragma comment(lib, "ntdll.lib")
 #pragma comment(lib, "powrprof.lib")
-#pragma comment(lib, "d3d9.lib")
-#pragma comment(lib, "d3d11.lib")
-#pragma comment(lib, "d3d12.lib")
 #pragma comment(lib, "dxgi.lib")
+#pragma comment(lib, "d3d9.lib")
 
 #elif (LINUX)
 #if (x86)
@@ -7509,9 +7505,9 @@ private: // START OF PRIVATE VM DETECTION TECHNIQUE DEFINITIONS
 
 #if (WINDOWS)
         constexpr u16 qpcRatioThreshold = 70;           // QPC ratio threshold
+#endif
         constexpr u8 tscIterations = 10;                 // Number of iterations for the TSC synchronization check
         constexpr u16 tscSyncDiffThreshold = 5000;  // TSC difference threshold
-#endif
 
         // to minimize context switching/scheduling
 #if (WINDOWS)


### PR DESCRIPTION
- Made constant enumeration of supported platforms in the documentation of each technique. For example, instead of typing "Windows, Linux" in some places and "Linux and Windows" in some others, it's now "Linux and Windows" on all places 

------------

- Merged VM::OFFSEC_SIDT and VM::VPC_SIDT into VM::SIDT
- Merged VM::OFFSEC_SGDT into VM::SGDT
- Merged VM::OFFSEC_SLDT into VM::SLDT
- Made VM::SIDT and VM::SGDT fully compatible with x64 and Clang/GCC/MSVC

------------

- Rewrote CODE DOCUMENTATION section at the beggining of the library to fix some small grammatical mistakes
- Rewrote category sections of some techniques to specify that they are only compatible with x86_32 rather than x86
 
------------

- Improved speed of VM::GPU_CAPABILITIES
- Improved speed of VM::GPU_NAMES

------------

- Adjusted thresholds on VM::TIMER function based on more empirical data
- Made vCPU TSC sync check compatible with Linux
- Added exception handling for single-core systems in the RDTSC spammer check and shared TSC check