### PR TITLE
clang pragma re-ordering

### DIFF
--- a/auxiliary/benchmark.cpp
+++ b/auxiliary/benchmark.cpp
@@ -81,7 +81,22 @@ public:
     }
 };
 
+static void enable_ansi_on_windows() {
+#if defined(_WIN32)
+    HANDLE hOut = GetStdHandle(STD_OUTPUT_HANDLE);
+    if (hOut == INVALID_HANDLE_VALUE) return;
+
+    DWORD dwMode = 0;
+    if (!GetConsoleMode(hOut, &dwMode)) return;
+
+    dwMode |= ENABLE_VIRTUAL_TERMINAL_PROCESSING | DISABLE_NEWLINE_AUTO_RETURN;
+    SetConsoleMode(hOut, dwMode);
+#endif
+}
+
 int main(void) {
+    enable_ansi_on_windows();
+
     // Measurement variables
     uint64_t start, end;
     bool is_detected;

--- a/src/vmaware.hpp
+++ b/src/vmaware.hpp
@@ -3640,8 +3640,6 @@ private: // START OF PRIVATE VM DETECTION TECHNIQUE DEFINITIONS
 /* GPL */ 
 /* GPL */         WORD iLength = sizeof(szDirectories) / sizeof(szDirectories[0]);
 /* GPL */         for (int i = 0; i < iLength; i++) {
-/* GPL */             TCHAR msg[256] = _T("");
-/* GPL */ 
 /* GPL */             if (util::is_wow64())
 /* GPL */                 ExpandEnvironmentStrings(_T("%ProgramW6432%"), szProgramFile, ARRAYSIZE(szProgramFile));
 /* GPL */             else
@@ -7758,10 +7756,10 @@ private: // START OF PRIVATE VM DETECTION TECHNIQUE DEFINITIONS
      * @author Requiem (https://github.com/NotRequiem)
      * @implements VM::TIMER
      */
-#if (MSVC)
-    #pragma optimize("", off)
-#elif (CLANG)
+#if (CLANG)
     #pragma clang optimize off
+#elif (MSVC)
+    #pragma optimize("", off)
 #elif (GCC)
     #pragma GCC push_options
     #pragma GCC optimize("O0")
@@ -8058,10 +8056,10 @@ private: // START OF PRIVATE VM DETECTION TECHNIQUE DEFINITIONS
         return false;
 #endif
     }
-#if (MSVC)
-    #pragma optimize("", on)
-#elif (CLANG)
-    #pragma clang optimize on
+#if (CLANG)
+    #pragma clang optimize off
+#elif (MSVC)
+    #pragma optimize("", off)
 #elif (GCC)
     #pragma GCC pop_options
 #endif


### PR DESCRIPTION
re-ordered optimization directives
removed some stupid unused variable
cross-platform ASCII escapes for benchmarking