### PR TITLE
Fix VM::DISABLE function error

### DIFF
--- a/src/vmaware.hpp
+++ b/src/vmaware.hpp
@@ -9122,7 +9122,7 @@ private: // START OF PRIVATE VM DETECTION TECHNIQUE DEFINITIONS
             flags.flip(MULTIPLE);
             flags.flip(DEFAULT);
         }
-        
+
         static void generate_current_disabled_flags(flagset& flags) {
             const bool setting_no_memo = flags.test(NO_MEMO);
             const bool setting_high_threshold = flags.test(HIGH_THRESHOLD);
@@ -9339,7 +9339,7 @@ private: // START OF PRIVATE VM DETECTION TECHNIQUE DEFINITIONS
             }
 
             handle_disabled_args(std::forward<Args>(args)...);
-            
+
             // check if a settings flag is set, which is not valid
             if (core::is_setting_flag_set(disabled_flag_collector)) {
                 throw std::invalid_argument("VM::DISABLE() must not contain a settings flag, they are disabled by default anyway");


### PR DESCRIPTION
##  MAKE SURE TO READ THE CONTRIBUTION GUIDELINES BEFORE CONTINUING!

<br>

## What does this PR do?
- [ ] Add a new technique
- [ ] Add a new feature
- [ ] Improve code
- [x] Fix bugs
- [ ] Refactoring or code organisation
- [ ] Stylistic changes
- [ ] Sync between branches
- [ ] Other

## Briefly explain what this PR does:
The following error always occurs when calling the VM::DISABLE function.  
`VM::DISABLE() must not contain a settings flag, they are disabled by default anyway`
This is because in the disabled_arg_handler function, generate_default initializes the disabled_flag_collector, but since generate_default doesn't flip VM::DEFAULT, the disabled_flag_collector always contains VM::DEFAULT, so it fails the core::is_setting_flag_set check.  
I created a new reset_disable_flagset function to fix this.  
In addition, the arg_handler operation has the same logic as the generate_current_disabled_flags already defined, and generate_current_disabled_flags are not being used, so I modified that logic to use generate_current_disabled_flags.