### PR TITLE
2.5.0-prerelease patches 

### DIFF
--- a/src/cli.cpp
+++ b/src/cli.cpp
@@ -1059,7 +1059,7 @@ static void generate_json(const std::string &output) {
     if (detected_status.size() == 0) {
         json.push_back("]\n}");
     } else {
-        for (u8 i = 0; i < detected_status.size(); i++) {
+        for (size_t i = 0; i < detected_status.size(); i++) {
             json.push_back("\n\t\t\"");
             json.push_back(VM::flag_to_string(detected_status.at(i)));
 


### PR DESCRIPTION
`[*]` Improved RDTSC patch detections 
`[*]` Made hyper-x debug messages clearer

`[/]` Fixed detection for QEMU's Hyper-V enlightenments
`[/]` Fixed **possible** false flag when probing VMware's Virtual Machine Communication Interface
`[/]` Fixed **possible** false flag when attempting to detect Hyper-V's VMBUS