### PR TITLE
Add Support for Down to Windows 7 in the CLI by default

### DIFF
--- a/README_CN.md
+++ b/README_CN.md
@@ -297,6 +297,7 @@ endif()
 - [luukjp](https://github.com/luukjp)
 - [Randark](https://github.com/Randark-JMT)
 - [Scrut1ny](https://github.com/Scrut1ny)
+- [Christopher Lentocha](https://github.com/CE1CECL)
 
 <br>
 

--- a/README_FR.md
+++ b/README_FR.md
@@ -292,6 +292,7 @@ Et si ce projet vous a été utile, un star serait très apprécié :)
 - [luukjp](https://github.com/luukjp)
 - [Randark](https://github.com/Randark-JMT)
 - [Scrut1ny](https://github.com/Scrut1ny)
+- [Christopher Lentocha](https://github.com/CE1CECL)
 
 <br>
 

--- a/README_KR.md
+++ b/README_KR.md
@@ -299,6 +299,8 @@ endif()
 - [Kyun-J](https://github.com/Kyun-J)
 - [luukjp](https://github.com/luukjp)
 - [Randark](https://github.com/Randark-JMT)
+- [Scrut1ny](https://github.com/Scrut1ny)
+- [Christopher Lentocha](https://github.com/CE1CECL)
 
 <br>
 

--- a/src/cli.cpp
+++ b/src/cli.cpp
@@ -40,6 +40,14 @@
     #define CLI_WINDOWS 1
     #define WIN32_LEAN_AND_MEAN
     #define NOMINMAX
+    #ifdef _WIN32_WINNT
+        #undef _WIN32_WINNT
+    #endif
+    #ifdef WINVER
+        #undef WINVER
+    #endif
+    #define _WIN32_WINNT 0x0601
+    #define WINVER 0x0601
     #include <windows.h>
 #else
     #define CLI_WINDOWS 0

--- a/src/vmaware.hpp
+++ b/src/vmaware.hpp
@@ -24,6 +24,7 @@
  *      - Kyun-J (https://github.com/Kyun-J)
  *      - luukjp (https://github.com/luukjp)
  *      - Lorenzo Rizzotti (https://github.com/Dreaming-Codes) 
+ *      - Christopher Lentocha (https://github.com/CE1CECL) 
  *  - Repository: https://github.com/kernelwernel/VMAware
  *  - Docs: https://github.com/kernelwernel/VMAware/docs/documentation.md
  *  - Full credits: https://github.com/kernelwernel/VMAware#credits-and-contributors-%EF%B8%8F


### PR DESCRIPTION
Don't add it to the `vmaware.hpp`, to prevent any external apps that may require newer a Windows versions at all (if XYZ app is heavy-dependant on VMAware, & to prevent XYZ app dev from reordering headers/defining more `_WIN32_WINNT`'s in their own apps for no-reason.
This will be usefull for 86Box/PCem detection testing, as they can only run up to Windows 7 (they are retro PC emulators after all, still considered VMs to me)