### PR TITLE
Definitive removal of HPET detections

### DIFF
--- a/src/vmaware.hpp
+++ b/src/vmaware.hpp
@@ -11154,7 +11154,7 @@ private: // START OF PRIVATE VM DETECTION TECHNIQUE DEFINITIONS
         }
 
         // The RTC (ACPI/CMOS RTC) timer can't be always detected via SetupAPI, it needs AML decode of the DSDT firmware table
-        // The HPET (PNP0103) timer presence is already checked on VM::FIRMWARE
+        // The HPET (PNP0103) timer presence check was removed, more info at: https://github.com/kernelwernel/VMAware/pull/616
         // Here, we check for the PIT/AT timer (PC-class System Timer)
         constexpr wchar_t pattern[] = L"pnp0100"; 
         constexpr size_t patLen = (sizeof(pattern) / sizeof(wchar_t)) - 1;


### PR DESCRIPTION
Reasons:
- HPET discontinued in Coffee Lake, Ice Lake and Coffee Lake-H variants in the Linux kernel
*HPET was explicitly disabled for Intel Ice Lake platforms and since then the kernel moved from per-CPU/PCI-ID blacklists to a behavior check (PC10 aka idle-state detection) that automatically covers other recent Intel SoCs (so the "where" is now more about behavior than a fixed chipset list). The Linux kernel later basically replaced the "add PCI IDs for each buggy model" approach with a idle state check that disables HPET when the platform exhibits the problematic behavior*

https://www.phoronix.com/news/Linux-Disabling-HPET-CoffeeLake
<img width="549" height="58" alt="image" src="https://github.com/user-attachments/assets/f2aec3ac-4bc2-4ee2-97bd-b3aee91cdb05" />
<img width="983" height="784" alt="image" src="https://github.com/user-attachments/assets/f48ae37c-f2be-494e-9632-2acf974d1ff0" />

- I've detected several manufacturers exposing buggy firmware that didnt reveal the presence of HPET, in both Windows and Linux.
```
constexpr whitelist_entry whitelist[] = {
    { "hp",         "omen"    },
    { "micro-star", "bravo"   },
    { "asustek",    "fa" }, // fa506, fa507, fa707, etc...
    { "asustek",    "Vivobook_ASUSLaptop" },
    { "asustek",    "ROG Strix"} // G513RM, etc...
};
```
As an example, the Asus TUF gaming a15 fa506nf with a AMD Ryzen 5 7535hs cpu exposes a HPET entry on its DSDT firmware table, but its disfunctional:
https://www.driveridentifier.com/scan/asustek-asus-tuf-gaming-a15-fa506nffa506nf-driver/desktop/16A22B6853874759AEFC28C1F3A38B2A
<img width="1109" height="220" alt="image" src="https://github.com/user-attachments/assets/2a84591c-7d7a-4207-a437-eeb67b8ad6e5" />

**This would lead us to consistently keep tracking motherboards where the kernel might falsely report the absence of HPET, apart from disabling any detection of this clock in non x86 systems. For production-level accuracy, I've decided to remove the support for this detection.**