### PR TITLE
Add FADT Hypervisor Vendor Identity check to VM::FIRMWARE

### DIFF
--- a/src/vmaware.hpp
+++ b/src/vmaware.hpp
@@ -6610,7 +6610,7 @@ private: // START OF PRIVATE VM DETECTION TECHNIQUE DEFINITIONS
                     memcpy(&hypervisor_vid, buffer + 268, 8);
 
                     if (hypervisor_vid != 0) {
-                        debug("FIRMWARE: FADT 'Hypervisor Vendor Identity' field is occupied");
+                        debug("FIRMWARE: FACP 'Hypervisor Vendor Identity' field is occupied");
                         return true;
                     }
                 }


### PR DESCRIPTION
##  MAKE SURE TO READ THE CONTRIBUTION GUIDELINES BEFORE CONTINUING!

<br>

## What does this PR do?
- [ ] Add a new technique
- [x] Add a new feature
- [ ] Add a new README translation
- [x] Improve code
- [ ] Fix bugs
- [ ] Refactoring or code organisation
- [ ] Stylistic changes
- [ ] Sync between branches
- [ ] Other

## Briefly explain what this PR does:
Adds detection for the FADT 'Hypervisor Vendor Identity' field at offset 268 (8 bytes). Per ACPI 6.0+ spec, firmware places zero bytes if no hypervisor is present. Non-zero value indicates hypervisor.

- https://uefi.org/sites/default/files/resources/ACPI_Spec_6.6.pdf#subsection.5.2.9

<img width="1031" height="292" alt="image" src="https://github.com/user-attachments/assets/f287d0f2-5435-4856-a1ba-8f710b0e9069" />
