### PR TITLE
fix compilation in vs2025

### DIFF
--- a/src/vmaware.hpp
+++ b/src/vmaware.hpp
@@ -10906,9 +10906,9 @@ private: // START OF PRIVATE VM DETECTION TECHNIQUE DEFINITIONS
 
         // ok so if the CPU is intel, the motherboard should be intel aswell (and same with AMD)
         // this doesnt happen in most public hardened configs out there so lets abuse it
-        constexpr unsigned int VID_INTEL = 0x8086;
-        constexpr unsigned int VID_AMD_ATI = 0x1002;
-        constexpr unsigned int VID_AMD_MICRO = 0x1022;
+        static constexpr unsigned int VID_INTEL = 0x8086;
+        static constexpr unsigned int VID_AMD_ATI = 0x1002;
+        static constexpr unsigned int VID_AMD_MICRO = 0x1022;
 
         enum class MBVendor { Unknown = 0, Intel = 1, AMD = 2 };
 


### PR DESCRIPTION
##  MAKE SURE TO READ THE CONTRIBUTION GUIDELINES BEFORE CONTINUING!

<br>

## What does this PR do?
- [ ] Add a new technique
- [ ] Add a new feature
- [ ] Add a new README translation
- [ ] Improve code
- [X] Fix bugs
- [ ] Refactoring or code organisation
- [ ] Stylistic changes
- [ ] Sync between branches
- [ ] Other

## Briefly explain what this PR does:

Compilation error in Visual Studio 2025 (C++17, v143)

> 1>Source\ThirdParty\Include\vmaware.hpp(11030,40): error C3493: 'VID_INTEL' cannot be passed implicitly because no default transfer mode is specified
> 1>Source\ThirdParty\Include\vmaware.hpp(11031,45): error C3493: 'VID_AMD_ATI' cannot be passed implicitly because no default transfer mode is specified
> 1>Source\ThirdParty\Include\vmaware.hpp(11031,67): error C3493: 'VID_AMD_MICRO' cannot be passed implicitly because no default transfer mode is specified default
> 1>Source\ThirdParty\Include\vmaware.hpp(11061,33): error C2064: fragment does not evaluate to a function that takes 0 arguments
> 1>Source\ThirdParty\Include\vmaware.hpp(11061,24): error C2737: "vendor": const object must be initialized