### PR TITLE
Add SVM instruction exception hypervisor detection

### DIFF
--- a/src/cli/output.cpp
+++ b/src/cli/output.cpp
@@ -580,7 +580,7 @@ void general(bool high_threshold, bool all, bool dynamic) {
     checker(VM::HYPERVISOR_HOOK, "EPT/NPT hooking");
     checker(VM::SINGLE_STEP, "single step behavior");
     checker(VM::EIP_OVERFLOW, "instructions in compat mode");
-    checker(VM::SVM_EXCEPTIONS, "SVM instruction exceptions");
+    checker(VM::SVM_EXCEPTIONS, "SVM exceptions");
     checker(VM::CGROUP, "cgroup namespace");
     checker(VM::TIMER, "timing anomalies");
 

--- a/src/cli/output.cpp
+++ b/src/cli/output.cpp
@@ -580,7 +580,7 @@ void general(bool high_threshold, bool all, bool dynamic) {
     checker(VM::HYPERVISOR_HOOK, "EPT/NPT hooking");
     checker(VM::SINGLE_STEP, "single step behavior");
     checker(VM::EIP_OVERFLOW, "instructions in compat mode");
-    checker(VM::SVM_INSTRUCTION_EXCEPTIONS, "SVM instruction exceptions");
+    checker(VM::SVM_EXCEPTIONS, "SVM instruction exceptions");
     checker(VM::CGROUP, "cgroup namespace");
     checker(VM::TIMER, "timing anomalies");
 

--- a/src/cli/output.cpp
+++ b/src/cli/output.cpp
@@ -580,6 +580,7 @@ void general(bool high_threshold, bool all, bool dynamic) {
     checker(VM::HYPERVISOR_HOOK, "EPT/NPT hooking");
     checker(VM::SINGLE_STEP, "single step behavior");
     checker(VM::EIP_OVERFLOW, "instructions in compat mode");
+    checker(VM::SVM_INSTRUCTION_EXCEPTIONS, "SVM instruction exceptions");
     checker(VM::CGROUP, "cgroup namespace");
     checker(VM::TIMER, "timing anomalies");
 

--- a/src/vmaware.hpp
+++ b/src/vmaware.hpp
@@ -13297,6 +13297,7 @@ public:
                         debug("SVM_INSTRUCTION_EXCEPTIONS: #GP with SVM CPUID visible, VM detected");
                     } else {
                         debug("SVM_INSTRUCTION_EXCEPTIONS: #GP with SVM CPUID hidden, VM spoofing CPUID detected");
+                        core::add(brand_enum::NULL_BRAND, 100);
                     }
 
                     return true;
@@ -14590,7 +14591,7 @@ std::array<VM::core::technique, VM::enum_size + 1> VM::core::technique_table = [
             {VM::KVM_INTERCEPTION, {100, VM::kvm_interception}},
             {VM::INTERRUPT_SHADOW, {100, VM::interrupt_shadow}},
             {VM::EIP_OVERFLOW, {100, VM::eip_overflow}},
-            {VM::SVM_INSTRUCTION_EXCEPTIONS, {75, VM::svm_instruction_exceptions}},
+            {VM::SVM_INSTRUCTION_EXCEPTIONS, {25, VM::svm_instruction_exceptions}},
             {VM::HYPERVISOR_HOOK, {100, VM::hypervisor_hook}},
             {VM::SINGLE_STEP, {100, VM::single_step}},
             {VM::NVRAM, {100, VM::nvram}},

--- a/src/vmaware.hpp
+++ b/src/vmaware.hpp
@@ -13212,7 +13212,7 @@ public:
             } ci_info = { sizeof(SYSTEM_CODEINTEGRITY_INFORMATION), 0 };
 
             constexpr ULONG SystemCodeIntegrityInformation = 103;
-            constexpr ULONG CODEINTEGRITY_OPTION_HVCI_KMCI_ENABLED = 0x400;
+            constexpr ULONG hvci_kmci_enabled_flag = 0x400;
 
             NTSTATUS status = nt_query_system_information(
                 SystemCodeIntegrityInformation,

--- a/src/vmaware.hpp
+++ b/src/vmaware.hpp
@@ -13212,7 +13212,7 @@ public:
             } ci_info = { sizeof(SYSTEM_CODEINTEGRITY_INFORMATION), 0 };
 
             constexpr ULONG SystemCodeIntegrityInformation = 103;
-                constexpr ULONG CODEINTEGRITY_OPTION_HVCI_KMCI_ENABLED = 0x400;
+            constexpr ULONG CODEINTEGRITY_OPTION_HVCI_KMCI_ENABLED = 0x400;
 
             NTSTATUS status = nt_query_system_information(
                 SystemCodeIntegrityInformation,

--- a/src/vmaware.hpp
+++ b/src/vmaware.hpp
@@ -598,7 +598,7 @@ public:
         HYPERVISOR_HOOK,
         SINGLE_STEP,
         EIP_OVERFLOW,
-        SVM_INSTRUCTION_EXCEPTIONS,
+        SVM_EXCEPTIONS,
 
         // Linux and Windows
         SYSTEM_REGISTERS,
@@ -13181,17 +13181,17 @@ public:
     /**
      * @brief Check whether a hypervisor leaks EFER.SVME into guest context via SVM instruction fault type
      * @category Windows, x86_64, AMD
-     * @implements VM::SVM_INSTRUCTION_EXCEPTIONS
+     * @implements VM::SVM_EXCEPTIONS
      */
-    [[nodiscard]] static bool svm_instruction_exceptions() {
+    [[nodiscard]] static bool svm_exceptions() {
         if (!x86 || !cpu::is_amd()) {
-            debug("SVM_INSTRUCTION_EXCEPTIONS: neither AMD or x86 detected, skipping");
+            debug("SVM_EXCEPTIONS: neither AMD or x86 detected, skipping");
             return false;
         }
 
         const auto hx = util::hyper_x();
         if (hx == HYPERV_ARTIFACT_VM || hx == HYPERV_REAL_VM || hx == HYPERV_ENLIGHTENMENT) {
-            debug("SVM_INSTRUCTION_EXCEPTIONS: Hyper-V active, skipping");
+            debug("SVM_EXCEPTIONS: Hyper-V active, skipping");
             return false;
         }
 
@@ -13294,9 +13294,9 @@ public:
                     }
 
                     if (svmcpuid_visible) {
-                        debug("SVM_INSTRUCTION_EXCEPTIONS: #GP with SVM CPUID visible, VM detected");
+                        debug("SVM_EXCEPTIONS: #GP with SVM CPUID visible, VM detected");
                     } else {
-                        debug("SVM_INSTRUCTION_EXCEPTIONS: #GP with SVM CPUID hidden, VM spoofing CPUID detected");
+                        debug("SVM_EXCEPTIONS: #GP with SVM CPUID hidden, VM spoofing CPUID detected");
                         core::add(brand_enum::NULL_BRAND, 100);
                     }
 
@@ -14072,7 +14072,7 @@ public:
             case HYPERVISOR_HOOK: return "HYPERVISOR_HOOK";
             case SINGLE_STEP: return "SINGLE_STEP";
             case EIP_OVERFLOW: return "EIP_OVERFLOW";
-            case SVM_INSTRUCTION_EXCEPTIONS: return "SVM_INSTRUCTION_EXCEPTIONS";
+            case SVM_EXCEPTIONS: return "SVM_EXCEPTIONS";
             case CGROUP: return "CGROUP";
             // END OF TECHNIQUE LIST
             case DEFAULT: return "DEFAULT"; 
@@ -14591,7 +14591,7 @@ std::array<VM::core::technique, VM::enum_size + 1> VM::core::technique_table = [
             {VM::KVM_INTERCEPTION, {100, VM::kvm_interception}},
             {VM::INTERRUPT_SHADOW, {100, VM::interrupt_shadow}},
             {VM::EIP_OVERFLOW, {100, VM::eip_overflow}},
-            {VM::SVM_INSTRUCTION_EXCEPTIONS, {25, VM::svm_instruction_exceptions}},
+            {VM::SVM_EXCEPTIONS, {25, VM::svm_exceptions}},
             {VM::HYPERVISOR_HOOK, {100, VM::hypervisor_hook}},
             {VM::SINGLE_STEP, {100, VM::single_step}},
             {VM::NVRAM, {100, VM::nvram}},

--- a/src/vmaware.hpp
+++ b/src/vmaware.hpp
@@ -598,6 +598,7 @@ public:
         HYPERVISOR_HOOK,
         SINGLE_STEP,
         EIP_OVERFLOW,
+        SVM_INSTRUCTION_EXCEPTIONS,
 
         // Linux and Windows
         SYSTEM_REGISTERS,
@@ -13177,7 +13178,155 @@ public:
         return hypervisor_detected;
     #endif  
     }
-    // ADD NEW TECHNIQUE FUNCTION HERE
+    /**
+     * @brief Check whether a hypervisor leaks EFER.SVME into guest context via SVM instruction fault type
+     * @category Windows, x86_64, AMD
+     * @implements VM::SVM_INSTRUCTION_EXCEPTIONS
+     */
+    [[nodiscard]] static bool svm_instruction_exceptions() {
+        if (!x86 || !cpu::is_amd()) {
+            debug("SVM_INSTRUCTION_EXCEPTIONS: neither AMD or x86 detected, returned false");
+            return false;
+        }
+
+        const HMODULE ntdll = util::get_ntdll();
+
+        if (!ntdll) {
+            return false;
+        }
+
+        // Skip if HVCI is active — SVME will be armed by the hypervisor
+        // legitimately, causing #GP on bare metal and producing a false positive
+        using nt_query_system_information_t = NTSTATUS(__stdcall*)(ULONG, PVOID, ULONG, PULONG);
+
+        const char* hvci_names[] = { "NtQuerySystemInformation" };
+        void* hvci_funcs[1] = {};
+        util::get_function_address(ntdll, hvci_names, hvci_funcs, 1);
+
+        const auto nt_query_system_information = reinterpret_cast<nt_query_system_information_t>(hvci_funcs[0]);
+
+        if (nt_query_system_information) {
+            struct SYSTEM_CODEINTEGRITY_INFORMATION {
+                ULONG Length;
+                ULONG CodeIntegrityOptions;
+            } ci_info = { sizeof(SYSTEM_CODEINTEGRITY_INFORMATION), 0 };
+
+            constexpr ULONG SystemCodeIntegrityInformation = 103;
+                constexpr ULONG CODEINTEGRITY_OPTION_HVCI_KMCI_ENABLED = 0x400;
+
+            NTSTATUS status = nt_query_system_information(
+                SystemCodeIntegrityInformation,
+                &ci_info,
+                sizeof(ci_info),
+                nullptr
+            );
+
+            if (NT_SUCCESS(status)) {
+                if (ci_info.CodeIntegrityOptions & CODEINTEGRITY_OPTION_HVCI_KMCI_ENABLED) {
+                    debug("SVM_INSTRUCTION_EXCEPTIONS: HVCI is active, skipping to avoid false positive");
+                    return false;
+                }
+            }
+        }
+
+        using nt_allocate_virtual_memory_t = NTSTATUS(__stdcall*)(HANDLE, PVOID*, ULONG_PTR, PSIZE_T, ULONG, ULONG);
+        using nt_protect_virtual_memory_t = NTSTATUS(__stdcall*)(HANDLE, PVOID*, PSIZE_T, ULONG, PULONG);
+        using nt_free_virtual_memory_t = NTSTATUS(__stdcall*)(HANDLE, PVOID*, PSIZE_T, ULONG);
+        using nt_flush_instruction_cache_t = NTSTATUS(__stdcall*)(HANDLE, PVOID, SIZE_T);
+
+        const char* names[] = {
+            "NtAllocateVirtualMemory",
+            "NtProtectVirtualMemory",
+            "NtFreeVirtualMemory",
+            "NtFlushInstructionCache"
+        };
+
+        void* funcs[ARRAYSIZE(names)] = {};
+        util::get_function_address(ntdll, names, funcs, ARRAYSIZE(names));
+
+        const auto nt_allocate_virtual_memory = reinterpret_cast<nt_allocate_virtual_memory_t>(funcs[0]);
+        const auto nt_protect_virtual_memory  = reinterpret_cast<nt_protect_virtual_memory_t>(funcs[1]);
+        const auto nt_free_virtual_memory     = reinterpret_cast<nt_free_virtual_memory_t>(funcs[2]);
+        const auto nt_flush_instruction_cache = reinterpret_cast<nt_flush_instruction_cache_t>(funcs[3]);
+
+        if (
+            (!nt_allocate_virtual_memory) ||
+            (!nt_protect_virtual_memory)  ||
+            (!nt_free_virtual_memory)     ||
+            (!nt_flush_instruction_cache)
+        ) {
+            return false;
+        }
+        
+
+        constexpr u8 opcodes[][4] = {
+            { 0x0F, 0x01, 0xD8, 0xC3 }, // VMRUN
+            { 0x0F, 0x01, 0xDA, 0xC3 }, // VMLOAD
+            { 0x0F, 0x01, 0xDB, 0xC3 }, // VMSAVE
+            { 0x0F, 0x01, 0xDD, 0xC3 }, // CLGI
+            { 0x0F, 0x01, 0xDF, 0xC3 }  // INVLPGA
+        };
+
+        const HANDLE current_process = reinterpret_cast<HANDLE>(-1);
+        constexpr u32 opcode_size = 4;
+
+        for (const auto& opcode : opcodes) {
+            PVOID base_address = nullptr;
+            SIZE_T region_size = 0x1000;
+
+            NTSTATUS status = nt_allocate_virtual_memory(
+                current_process, &base_address, 0, &region_size,
+                MEM_COMMIT | MEM_RESERVE, PAGE_EXECUTE_READWRITE
+            );
+
+            if (!NT_SUCCESS(status)) {
+                continue;
+            }
+
+            memcpy(base_address, opcode, opcode_size);
+            nt_flush_instruction_cache(current_process, base_address, opcode_size);
+
+            ULONG old_protect = 0;
+            PVOID protect_address = base_address;
+            SIZE_T protect_size = region_size;
+            
+            status = nt_protect_virtual_memory(
+                current_process, &protect_address, &protect_size,
+                PAGE_EXECUTE_READ, &old_protect
+            );
+
+            if (NT_SUCCESS(status)) {
+                nt_flush_instruction_cache(current_process, base_address, opcode_size);
+
+                DWORD exception_status = 0;
+                bool fault_hit = false;
+
+                __try {
+                    const auto execute_svm = reinterpret_cast<void(*)()>(base_address);
+                    execute_svm();
+                }
+                __except (exception_status = GetExceptionCode(), EXCEPTION_EXECUTE_HANDLER) {
+                    fault_hit = true;
+                }
+
+                SIZE_T free_size = 0;
+                nt_free_virtual_memory(current_process, &base_address, &free_size, MEM_RELEASE);
+
+                if (fault_hit) {
+                    if (exception_status != EXCEPTION_ILLEGAL_INSTRUCTION) {
+                        return true;
+                    }
+                }
+            } else {
+                SIZE_T free_size = 0;
+                nt_free_virtual_memory(current_process, &base_address, &free_size, MEM_RELEASE);
+            }
+        }
+
+        return false;
+    }
+
+    
 
     #if (CLANG)
         #pragma clang diagnostic pop
@@ -13935,6 +14084,7 @@ public:
             case HYPERVISOR_HOOK: return "HYPERVISOR_HOOK";
             case SINGLE_STEP: return "SINGLE_STEP";
             case EIP_OVERFLOW: return "EIP_OVERFLOW";
+            case SVM_INSTRUCTION_EXCEPTIONS: return "SVM_INSTRUCTION_EXCEPTIONS";
             case CGROUP: return "CGROUP";
             // END OF TECHNIQUE LIST
             case DEFAULT: return "DEFAULT"; 
@@ -14453,6 +14603,7 @@ std::array<VM::core::technique, VM::enum_size + 1> VM::core::technique_table = [
             {VM::KVM_INTERCEPTION, {100, VM::kvm_interception}},
             {VM::INTERRUPT_SHADOW, {100, VM::interrupt_shadow}},
             {VM::EIP_OVERFLOW, {100, VM::eip_overflow}},
+            {VM::SVM_INSTRUCTION_EXCEPTIONS, {75, VM::svm_instruction_exceptions}},
             {VM::HYPERVISOR_HOOK, {100, VM::hypervisor_hook}},
             {VM::SINGLE_STEP, {100, VM::single_step}},
             {VM::NVRAM, {100, VM::nvram}},

--- a/src/vmaware.hpp
+++ b/src/vmaware.hpp
@@ -13185,48 +13185,24 @@ public:
      */
     [[nodiscard]] static bool svm_instruction_exceptions() {
         if (!x86 || !cpu::is_amd()) {
-            debug("SVM_INSTRUCTION_EXCEPTIONS: neither AMD or x86 detected, returned false");
+            debug("SVM_INSTRUCTION_EXCEPTIONS: neither AMD or x86 detected, skipping");
             return false;
         }
+
+        const auto hx = util::hyper_x();
+        if (hx == HYPERV_ARTIFACT_VM || hx == HYPERV_REAL_VM || hx == HYPERV_ENLIGHTENMENT) {
+            debug("SVM_INSTRUCTION_EXCEPTIONS: Hyper-V active, skipping");
+            return false;
+        }
+
+        u32 eax = 0, ebx = 0, ecx = 0, edx = 0;
+        cpu::cpuid(eax, ebx, ecx, edx, 0x80000001);
+        const bool svmcpuid_visible = (ecx >> 2) & 1;
 
         const HMODULE ntdll = util::get_ntdll();
 
         if (!ntdll) {
             return false;
-        }
-
-        // Skip if HVCI is active — SVME will be armed by the hypervisor
-        // legitimately, causing #GP on bare metal and producing a false positive
-        using nt_query_system_information_t = NTSTATUS(__stdcall*)(ULONG, PVOID, ULONG, PULONG);
-
-        const char* hvci_names[] = { "NtQuerySystemInformation" };
-        void* hvci_funcs[1] = {};
-        util::get_function_address(ntdll, hvci_names, hvci_funcs, 1);
-
-        const auto nt_query_system_information = reinterpret_cast<nt_query_system_information_t>(hvci_funcs[0]);
-
-        if (nt_query_system_information) {
-            struct SYSTEM_CODEINTEGRITY_INFORMATION {
-                ULONG Length;
-                ULONG CodeIntegrityOptions;
-            } ci_info = { sizeof(SYSTEM_CODEINTEGRITY_INFORMATION), 0 };
-
-            constexpr ULONG SystemCodeIntegrityInformation = 103;
-            constexpr ULONG hvci_kmci_enabled_flag = 0x400;
-
-            NTSTATUS status = nt_query_system_information(
-                SystemCodeIntegrityInformation,
-                &ci_info,
-                sizeof(ci_info),
-                nullptr
-            );
-
-            if (NT_SUCCESS(status)) {
-                if (ci_info.CodeIntegrityOptions & CODEINTEGRITY_OPTION_HVCI_KMCI_ENABLED) {
-                    debug("SVM_INSTRUCTION_EXCEPTIONS: HVCI is active, skipping to avoid false positive");
-                    return false;
-                }
-            }
         }
 
         using nt_allocate_virtual_memory_t = NTSTATUS(__stdcall*)(HANDLE, PVOID*, ULONG_PTR, PSIZE_T, ULONG, ULONG);
@@ -13289,7 +13265,7 @@ public:
             ULONG old_protect = 0;
             PVOID protect_address = base_address;
             SIZE_T protect_size = region_size;
-            
+
             status = nt_protect_virtual_memory(
                 current_process, &protect_address, &protect_size,
                 PAGE_EXECUTE_READ, &old_protect
@@ -13313,9 +13289,17 @@ public:
                 nt_free_virtual_memory(current_process, &base_address, &free_size, MEM_RELEASE);
 
                 if (fault_hit) {
-                    if (exception_status != EXCEPTION_ILLEGAL_INSTRUCTION) {
-                        return true;
+                    if (exception_status == EXCEPTION_ILLEGAL_INSTRUCTION) {
+                        continue;
                     }
+
+                    if (svmcpuid_visible) {
+                        debug("SVM_INSTRUCTION_EXCEPTIONS: #GP with SVM CPUID visible, VM detected");
+                    } else {
+                        debug("SVM_INSTRUCTION_EXCEPTIONS: #GP with SVM CPUID hidden, VM spoofing CPUID detected");
+                    }
+
+                    return true;
                 }
             } else {
                 SIZE_T free_size = 0;
@@ -13325,6 +13309,9 @@ public:
 
         return false;
     }
+
+    // ADD NEW TECHNIQUE FUNCTION HERE
+
 
     
 


### PR DESCRIPTION
##  MAKE SURE TO READ THE CONTRIBUTION GUIDELINES BEFORE CONTINUING!

<br>

## What does this PR do?
- [X] Add a new technique
- [ ] Add a new feature
- [ ] Add a new README translation
- [ ] Improve code
- [ ] Fix bugs
- [ ] Refactoring or code organisation
- [ ] Stylistic changes
- [ ] Sync between branches
- [ ] Other

## Briefly explain what this PR does:

not the best at writing explanation but 
we added a new AMD-specific detection technique as VM::SVM_INSTRUCTION_EXCEPTIONS for windows x86_64 systems,

the code spots hypervisors by throwing SVM instructions (VMRUN, VMLOAD, VMSAVE, CLGI, INVLPGA) at the processor and watching how it reacts. if we are on bare metal and hvci is disabled and EFER.SVME is disabled, the CPU throws an invalid opcode exception (#UD / STATUS_ILLEGAL_INSTRUCTION), but if we are inside a VM and the hypervisor fails to properly intercept or handle the instruction and the system drops a general protection fault instead (#GP / STATUS_ACCESS_VIOLATION) giving away the virtualization layer.

and to prevent false positives we added hvci query to check for it.