### PR TITLE
Enhancement to VM::INTERRUPT_SHADOW

### DIFF
--- a/src/vmaware.hpp
+++ b/src/vmaware.hpp
@@ -10766,7 +10766,7 @@ public:
         if (is_hyperv) {
             if (!shadow_broken) {
                 debug("INTERRUPT_SHADOW: hyper-v present but shadow respected, VM hardening suspected");
-                core::add(brand_enum::HYPERV_ARTIFACT_VM, 75);
+                core::add(brand_enum::NULL_BRAND, 50);
             } else {
                 debug("INTERRUPT_SHADOW: hyper-v present and shadow broken, baremetal behaviour");
             }
@@ -10855,7 +10855,7 @@ public:
         if (is_hyperv) {
             if (!shadow_broken) {
                 debug("INTERRUPT_SHADOW: hyper-v present but shadow respected, VM hardening suspected");
-                core::add(brand_enum::HYPERV_ARTIFACT_VM, 75);
+                core::add(brand_enum::NULL_BRAND, 50);
             } else {
                 debug("INTERRUPT_SHADOW: hyper-v present and shadow broken, baremetal behaviour");
             }

--- a/src/vmaware.hpp
+++ b/src/vmaware.hpp
@@ -10729,7 +10729,9 @@ public:
      * @implements VM::INTERRUPT_SHADOW
      */
     [[nodiscard]] static bool interrupt_shadow() {
-        const bool is_hyperv = (util::hyper_x() == HYPERV_REAL_VM);
+        if (util::hyper_x() == HYPERV_ARTIFACT_VM) {
+                   return false;
+        }
         volatile ULONG_PTR trap_ip = 0;
 
     #if (x86_32) && !(CLANG || GCC)
@@ -10761,19 +10763,9 @@ public:
                 EXCEPTION_CONTINUE_EXECUTION
             ) : EXCEPTION_CONTINUE_SEARCH) {}
 
-        const bool shadow_broken = (trap_ip == 0 || trap_ip != baremetal_target_ip);
-
-        if (is_hyperv) {
-            if (!shadow_broken) {
-                debug("INTERRUPT_SHADOW: hyper-v present but shadow respected, VM hardening suspected");
-                core::add(brand_enum::NULL_BRAND, 50);
-            } else {
-                debug("INTERRUPT_SHADOW: hyper-v present and shadow broken, baremetal behaviour");
-            }
-            return false;
-        }
-
-        return shadow_broken;
+         // hypervisor is detected if the trap fired at any IP differing from the expected baremetal target
+        // OR if the single step exception never fired at all (trap_ip == 0)
+        return (trap_ip == 0 || trap_ip != baremetal_target_ip);
 
     #elif (x86_64) || ((x86_32) && (CLANG || GCC))
         const HMODULE ntdll = util::get_ntdll();
@@ -10850,19 +10842,7 @@ public:
 
         // hypervisor is detected if execution trapped at any offset other than expected baremetal
         // OR if the single step exception never fired at all (trap_ip == 0)
-        const bool shadow_broken = NT_SUCCESS(st) && (trap_ip == 0 || trap_ip != baremetal_target_ip);
-
-        if (is_hyperv) {
-            if (!shadow_broken) {
-                debug("INTERRUPT_SHADOW: hyper-v present but shadow respected, VM hardening suspected");
-                core::add(brand_enum::NULL_BRAND, 50);
-            } else {
-                debug("INTERRUPT_SHADOW: hyper-v present and shadow broken, baremetal behaviour");
-            }
-            return false;
-        }
-
-        return shadow_broken;
+      return NT_SUCCESS(st) && (trap_ip == 0 || trap_ip != baremetal_target_ip);
     #else
         return false;
     #endif

--- a/src/vmaware.hpp
+++ b/src/vmaware.hpp
@@ -10729,6 +10729,7 @@ public:
      * @implements VM::INTERRUPT_SHADOW
      */
     [[nodiscard]] static bool interrupt_shadow() {
+        const bool is_hyperv = (util::hyper_x() == HYPERV_REAL_VM);
         volatile ULONG_PTR trap_ip = 0;
 
     #if (x86_32) && !(CLANG || GCC)
@@ -10760,9 +10761,19 @@ public:
                 EXCEPTION_CONTINUE_EXECUTION
             ) : EXCEPTION_CONTINUE_SEARCH) {}
 
-        // hypervisor is detected if the trap fired at any IP differing from the expected baremetal target
-        // OR if the single step exception never fired at all (trap_ip == 0)
-        return (trap_ip == 0 || trap_ip != baremetal_target_ip);
+        const bool shadow_broken = (trap_ip == 0 || trap_ip != baremetal_target_ip);
+
+        if (is_hyperv) {
+            if (!shadow_broken) {
+                debug("INTERRUPT_SHADOW: hyper-v present but shadow respected, VM hardening suspected");
+                core::add(brand_enum::HYPERV_ARTIFACT_VM, 75);
+            } else {
+                debug("INTERRUPT_SHADOW: hyper-v present and shadow broken, baremetal behaviour");
+            }
+            return false;
+        }
+
+        return shadow_broken;
 
     #elif (x86_64) || ((x86_32) && (CLANG || GCC))
         const HMODULE ntdll = util::get_ntdll();
@@ -10775,30 +10786,30 @@ public:
         void* funcs[ARRAYSIZE(names)] = {};
         util::get_function_address(ntdll, names, funcs, ARRAYSIZE(names));
 
-        const auto nt_alloc = reinterpret_cast<NTSTATUS(__stdcall*)(HANDLE, PVOID*, ULONG_PTR, PSIZE_T, ULONG, ULONG)>(funcs[0]);
+        const auto nt_alloc   = reinterpret_cast<NTSTATUS(__stdcall*)(HANDLE, PVOID*, ULONG_PTR, PSIZE_T, ULONG, ULONG)>(funcs[0]);
         const auto nt_protect = reinterpret_cast<NTSTATUS(__stdcall*)(HANDLE, PVOID*, PSIZE_T, ULONG, PULONG)>(funcs[1]);
-        const auto nt_flush = reinterpret_cast<NTSTATUS(__stdcall*)(HANDLE, PVOID, SIZE_T)>(funcs[2]);
-        const auto nt_free = reinterpret_cast<NTSTATUS(__stdcall*)(HANDLE, PVOID*, PSIZE_T, ULONG)>(funcs[3]);
+        const auto nt_flush   = reinterpret_cast<NTSTATUS(__stdcall*)(HANDLE, PVOID, SIZE_T)>(funcs[2]);
+        const auto nt_free    = reinterpret_cast<NTSTATUS(__stdcall*)(HANDLE, PVOID*, PSIZE_T, ULONG)>(funcs[3]);
 
         if (!nt_alloc || !nt_protect || !nt_flush || !nt_free) return false;
 
         // these opcodes are byte-for-byte identical for both x86_32 and x86_64 architectures 
         // 0x53 maps to push ebx in 32-bit and push rbx in 64-bit
         static constexpr u8 blockstep_opcodes[] = {
-            0x53,                                     // 0:  push rbx/ebx (preserve non-volatile register)
-            0x31, 0xC0,                               // 1:  xor eax, eax
-            0x8C, 0xD0,                               // 3:  mov ax, ss
-            0x9C,                                     // 5:  pushfq/pushfd
+            0x53,                                      // 0:  push rbx/ebx (preserve non-volatile register)
+            0x31, 0xC0,                                // 1:  xor eax, eax
+            0x8C, 0xD0,                                // 3:  mov ax, ss
+            0x9C,                                      // 5:  pushfq/pushfd
             0x81, 0x0C, 0x24, 0x00, 0x01, 0x00, 0x00, // 6:  or dword ptr [rsp/esp], 0x100
-            0x9D,                                     // 13: popfq/popfd
-            0x8E, 0xD0,                               // 14: mov ss, ax  <- shadow starts here
-            0x0F, 0xA2,                               // 16: cpuid       <- buggy hypervisor traps here
-            0x5B,                                     // 18: pop rbx/ebx <- baremetal traps here
-            0x90,                                     // 19: nop         
-            0x9C,                                     // 20: pushfq/pushfd
+            0x9D,                                      // 13: popfq/popfd
+            0x8E, 0xD0,                                // 14: mov ss, ax  <- shadow starts here
+            0x0F, 0xA2,                                // 16: cpuid       <- buggy hypervisor traps here
+            0x5B,                                      // 18: pop rbx/ebx <- baremetal traps here
+            0x90,                                      // 19: nop         
+            0x9C,                                      // 20: pushfq/pushfd
             0x81, 0x24, 0x24, 0xFF, 0xFE, 0xFF, 0xFF, // 21: and dword ptr [rsp/esp], 0xFFFFFEFF
-            0x9D,                                     // 28: popfq/popfd
-            0xC3                                      // 29: ret
+            0x9D,                                      // 28: popfq/popfd
+            0xC3                                       // 29: ret
         };
 
         const HANDLE current_process = reinterpret_cast<HANDLE>(-1LL);
@@ -10830,7 +10841,7 @@ public:
                     trap_ip = GetExceptionInformation()->ContextRecord->Eip,
                 #endif
                     GetExceptionInformation()->ContextRecord->EFlags &= ~0x100, // to avoid infinite looping
-                    EXCEPTION_CONTINUE_EXECUTION 
+                    EXCEPTION_CONTINUE_EXECUTION
                 ) : EXCEPTION_CONTINUE_SEARCH) {}
         }
 
@@ -10839,7 +10850,19 @@ public:
 
         // hypervisor is detected if execution trapped at any offset other than expected baremetal
         // OR if the single step exception never fired at all (trap_ip == 0)
-        return NT_SUCCESS(st) && (trap_ip == 0 || trap_ip != baremetal_target_ip);
+        const bool shadow_broken = NT_SUCCESS(st) && (trap_ip == 0 || trap_ip != baremetal_target_ip);
+
+        if (is_hyperv) {
+            if (!shadow_broken) {
+                debug("INTERRUPT_SHADOW: hyper-v present but shadow respected, VM hardening suspected");
+                core::add(brand_enum::HYPERV_ARTIFACT_VM, 75);
+            } else {
+                debug("INTERRUPT_SHADOW: hyper-v present and shadow broken, baremetal behaviour");
+            }
+            return false;
+        }
+
+        return shadow_broken;
     #else
         return false;
     #endif


### PR DESCRIPTION


## What does this PR do?
- [ ] Add a new technique
- [ ] Add a new feature
- [ ] Add a new README translation
- [ ] Improve code
- [X] Fix bugs
- [ ] Refactoring or code organisation
- [ ] Stylistic changes
- [ ] Sync between branches
- [ ] Other

## Briefly explain what this PR does:
when hvci is enabled, the interrupt shadow doesnt get respected,i tested this on two different amd machines both running bare metal (amd cpu) so its definitely not a vm thing
so we might add a hyperv check for it
PC-1
<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/3680b0f4-4229-4c12-b55c-0aad5769ef61" />
<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/d1e5c585-405c-4d9b-b478-a734b462a403" />
PC-2
<img width="1920" height="1071" alt="image" src="https://github.com/user-attachments/assets/733cfc80-3042-4389-84a1-3b2f10674603" />
<img width="1636" height="912" alt="image" src="https://github.com/user-attachments/assets/ef091f5a-f8ec-4388-9a00-69653f9e5bfe" />
