### PR TITLE
Skip TIMER on Hyper-V root partition

### DIFF
--- a/src/vmaware.hpp
+++ b/src/vmaware.hpp
@@ -5508,6 +5508,12 @@ public:
      */
     [[nodiscard]] static bool timer() {
     #if (x86 && WINDOWS)
+        // Hyper-V root partition is the host, not a guest. Do not treat host-side
+        // timing variance as a VM signal.
+        if (util::hyper_x() == HYPERV_ARTIFACT_VM) {
+            return false;
+        }
+
         // The timing attack uses our own software-based clock, meaning a hypervisor can't hide time by offsetting TSC or controlling any other timer
         double threshold = 2.5;
         if (util::is_running_under_translator()) {


### PR DESCRIPTION
`hyper_x()` already distinguishes a Hyper-V root partition from a guest VM.

On Windows hosts with VBS/Hyper-V enabled, `VM::TIMER` can still report a VM signal under `--all`. That lets a timing heuristic override the root-partition classification and can produce a false VM brand.

This skips `VM::TIMER` for `HYPERV_ARTIFACT_VM`.

Tested on Windows 11 Enterprise 10.0.26200 with Hyper-V/VBS active:

```powershell
.\build\Release\vmaware.exe --no-relaunch --no-ansi --all --json --output result.json
```

Result remains `Hyper-V root partition (host system, not an actual VM)`.