### PR TITLE
fix: detect Hyper-V enlightenments on guests, not only root partitions

### DIFF
--- a/README.md
+++ b/README.md
@@ -365,6 +365,7 @@ And if you found this project useful, a star would be appreciated :)
 - [Juan Diego](https://github.com/w451)
 - [Wiisus](https://github.com/wiisus)
 - [Marcel](https://github.com/MarcelDev)
+- [Max Ufer](https://github.com/Manny684)
 
 <br>
 

--- a/src/vmaware.hpp
+++ b/src/vmaware.hpp
@@ -26,6 +26,7 @@
  *      - Lorenzo Rizzotti (https://github.com/Dreaming-Codes) 
  *      - virtfunc (https://github.com/virtfunc)
  *      - Wiisus (https://github.com/wiisus)
+ *      - Max Ufer (https://github.com/Manny684)
  *  - Repository: https://github.com/NotRequiem/VMAware
  *  - Docs: https://github.com/NotRequiem/VMAware/docs/documentation.md
  *  - Full credits: https://github.com/NotRequiem/VMAware#credits-and-contributors-%EF%B8%8F
@@ -1027,8 +1028,17 @@ public:
             const std::string brand_str = cpu_manufacturer(p_leaf);
 
             if (brand_str == "Microsoft Hv") {
-                if (util::hyper_x() == HYPERV_HOST) {
+                const auto hyperx = util::hyper_x();
+
+                // A Hyper-V *host* (root partition) is not itself a guest VM, and a QEMU/KVM guest
+                // running with Hyper-V enlightenments is already attributed to QEMU_KVM_HYPERV by
+                // hyper_x(). In neither case should the "Microsoft Hv" vendor string be taken to
+                // mean the guest is genuine Microsoft Hyper-V.
+                if (hyperx == HYPERV_HOST) {
                     return false;
+                }
+                if (hyperx == HYPERV_ENLIGHTENMENT) {
+                    return true; // VM detected via the vendor string; brand already set by hyper_x()
                 }
                 return core::add(brand_enum::HYPERV);
             }
@@ -4085,7 +4095,21 @@ public:
             }
             else {
                 if (!is_root_partition()) {
-                    if (eax() == 11 && is_hyperv_present()) {
+                    // A QEMU/KVM guest running with Hyper-V enlightenments presents "Microsoft Hv" at
+                    // leaf 0x40000000 (so the Windows guest uses the fast Hyper-V ABI) while KVM relocates
+                    // its own "KVMKVMKVM" signature to leaf 0x40000100. That secondary signature is an
+                    // unambiguous tell of QEMU/KVM. A guest is not a root partition, so this must be
+                    // checked here -- otherwise the enlightenment check exists only in the
+                    // is_root_partition() branch below, leaving enlightened guests (the common
+                    // case) misdetected as genuine Hyper-V.
+                    const std::string enlightenment_str = cpu::cpu_manufacturer(cpu::leaf::hypervisor + 0x100); // 0x40000100
+
+                    if (util::find(enlightenment_str, "KVM")) {
+                        debug("HYPER-X: Detected Hyper-V enlightenments");
+                        core::add(brand_enum::QEMU_KVM_HYPERV);
+                        state = HYPERV_ENLIGHTENMENT;
+                    }
+                    else if (eax() == 11 && is_hyperv_present()) {
                         // Windows machine running under Hyper-V type 2
                         debug("HYPER-X: Detected Hyper-V guest VM");
                         core::add(brand_enum::HYPERV);


### PR DESCRIPTION
## What does this PR do?
- [ ] Add a new technique
- [ ] Add a new feature
- [ ] Add a new README translation
- [ ] Improve code
- [x] Fix bugs
- [ ] Refactoring or code organisation
- [ ] Stylistic changes
- [ ] Sync between branches
- [ ] Other

## Briefly explain what this PR does:

Fixes misdetection of QEMU/KVM guests running with Hyper-V enlightenments, which were being reported as genuine Microsoft Hyper-V.

**Root cause**

A QEMU/KVM guest running with Hyper-V enlightenments presents `Microsoft Hv` at CPUID leaf `0x40000000` (so the Windows guest uses the fast Hyper-V ABI), while KVM relocates its `KVMKVMKVM` signature to leaf `0x40000100`. The `0x40000100` check that yields `HYPERV_ENLIGHTENMENT` / `QEMU_KVM_HYPERV` lived **only** in the root-partition branch of `hyper_x()`, which an ordinary guest never reaches.

Enlightened guests therefore fell through to the guest branch's `eax() == 11 && is_hyperv_present()` test, were classified `HYPERV_REAL_VM` and branded `HYPERV`; `vmid_template()` then saw `Microsoft Hv` and (since `hyper_x() != HYPERV_HOST`) added `brand_enum::HYPERV` as well. The final brand became "Microsoft Hyper-V" instead of "QEMU+KVM Hyper-V Enlightenment".
**Changes**

- `hyper_x()`: also check the `0x40000100` KVM signature in the guest branch, before the `eax() == 11` Hyper-V-guest test.
- `vmid_template()`: when `hyper_x()` reports `HYPERV_ENLIGHTENMENT`, still flag the VM via the `Microsoft Hv` vendor string but don't add the misleading `HYPERV` brand (already set to `QEMU_KVM_HYPERV` by `hyper_x()`).

No behavior change for real Hyper-V guests/hosts, nested Hyper-V, spoofers, or bare metal.

**References**

- QEMU documentation confirms the leaf relocation: <https://www.qemu.org/docs/master/system/i386/hyperv.html>. It states: *"When any set of the Hyper-V enlightenments is enabled, QEMU changes hypervisor identification (CPUID 0x40000000..0x4000000A) to Hyper-V. KVM identification and features are kept in leaves 0x40000100..0x40000101."*
- KVM CPUID bits: <https://docs.kernel.org/virt/kvm/x86/cpuid.html>
- Prior art: systemd hit the same misdetection and fixed it the same way: <https://github.com/systemd/systemd/issues/28001>
