### PR TITLE
Fix timing bug not pinning the triggering thread

### DIFF
--- a/README.md
+++ b/README.md
@@ -355,6 +355,7 @@ For email inquiries: `vmaware.support@gmail.com`
 - [Max Ufer](https://github.com/Manny684)
 - [Everdox](https://github.com/everdox)
 - [snackapps](https://github.com/snackapps)
+- [Bandwidth](https://github.com/bandw1dth)
  
 <br>
 

--- a/src/vmaware.hpp
+++ b/src/vmaware.hpp
@@ -5743,13 +5743,6 @@ public:
             const HANDLE current_thread = reinterpret_cast<HANDLE>(-2LL);
             const HANDLE current_process = reinterpret_cast<HANDLE>(-1LL);
             const DWORD_PTR old_affinity = SetThreadAffinityMask(current_thread, trigger_affinity);
-            if (!old_affinity) {
-                // Release the counter thread if Windows rejects the requested trigger CPU.
-                // Running unpinned would invalidate the topology guarantees established by getmask().
-                state.start_test.store(true, std::memory_order_release);
-                state.test_done.store(true, std::memory_order_release);
-                return;
-            }
             const int old_thread_priority = GetThreadPriority(current_thread);
             const DWORD old_process_priority = GetPriorityClass(current_process);
             SetPriorityClass(current_process, ABOVE_NORMAL_PRIORITY_CLASS); // ABOVE_NORMAL_PRIORITY_CLASS + THREAD_PRIORITY_HIGHEST = 12 base priority

--- a/src/vmaware.hpp
+++ b/src/vmaware.hpp
@@ -5742,7 +5742,14 @@ public:
 
             const HANDLE current_thread = reinterpret_cast<HANDLE>(-2LL);
             const HANDLE current_process = reinterpret_cast<HANDLE>(-1LL);
-            const DWORD_PTR old_affinity = trigger_affinity;
+            const DWORD_PTR old_affinity = SetThreadAffinityMask(current_thread, trigger_affinity);
+            if (!old_affinity) {
+                // Release the counter thread if Windows rejects the requested trigger CPU.
+                // Running unpinned would invalidate the topology guarantees established by getmask().
+                state.start_test.store(true, std::memory_order_release);
+                state.test_done.store(true, std::memory_order_release);
+                return;
+            }
             const int old_thread_priority = GetThreadPriority(current_thread);
             const DWORD old_process_priority = GetPriorityClass(current_process);
             SetPriorityClass(current_process, ABOVE_NORMAL_PRIORITY_CLASS); // ABOVE_NORMAL_PRIORITY_CLASS + THREAD_PRIORITY_HIGHEST = 12 base priority


### PR DESCRIPTION
If the triggering thread is not pinned, Windows can schedule it on CPU e.g., 8 or 9 despite our explicit request to exclude that core. It could consequently land on guest CPU 8/9 (the same host pCPU used by the counter), inflating measurements and creating two different classes (in my case, ~350-400 and ~80-100).

This fix performs the intended SetThreadAffinityMask() before measurement and aborts if pinning fails.